### PR TITLE
file: Fix race in closing

### DIFF
--- a/file.go
+++ b/file.go
@@ -61,6 +61,7 @@ type win32File struct {
 	handle        syscall.Handle
 	wg            sync.WaitGroup
 	closing       bool
+	closingLock   sync.RWMutex
 	readDeadline  time.Time
 	writeDeadline time.Time
 }
@@ -87,15 +88,24 @@ func MakeOpenFile(h syscall.Handle) (io.ReadWriteCloser, error) {
 
 // closeHandle closes the resources associated with a Win32 handle
 func (f *win32File) closeHandle() {
-	if !f.closing {
+	f.closingLock.Lock()
+	alreadyClosing := f.closing
+	f.closing = true
+	f.closingLock.Unlock()
+	if !alreadyClosing {
 		// cancel all IO and wait for it to complete
-		f.closing = true
 		cancelIoEx(f.handle, nil)
 		f.wg.Wait()
 		// at this point, no new IO can start
 		syscall.Close(f.handle)
 		f.handle = 0
 	}
+}
+
+func (f *win32File) isClosing() bool {
+	f.closingLock.RLock()
+	defer f.closingLock.RUnlock()
+	return f.closing
 }
 
 // Close closes a win32File.
@@ -108,7 +118,8 @@ func (f *win32File) Close() error {
 // prepareIo prepares for a new IO operation
 func (f *win32File) prepareIo() (*ioOperation, error) {
 	f.wg.Add(1)
-	if f.closing {
+	if f.isClosing() {
+		f.wg.Done()
 		return nil, ErrFileClosed
 	}
 	c := &ioOperation{}
@@ -142,7 +153,7 @@ func (f *win32File) asyncIo(c *ioOperation, deadline time.Time, bytes uint32, er
 		var r ioResult
 		wait := true
 		timedout := false
-		if f.closing {
+		if f.isClosing() {
 			cancelIoEx(f.handle, &c.o)
 		} else if !deadline.IsZero() {
 			now := time.Now()
@@ -166,7 +177,7 @@ func (f *win32File) asyncIo(c *ioOperation, deadline time.Time, bytes uint32, er
 		}
 		err = r.err
 		if err == syscall.ERROR_OPERATION_ABORTED {
-			if f.closing {
+			if f.isClosing() {
 				err = ErrFileClosed
 			} else if timedout {
 				err = ErrTimeout


### PR DESCRIPTION
Hello!

It looks like there's a race condition created in `(*win32File).closeHandle()` where multiple concurrent goroutines are accessing the `(*win32File).closing` field.  This shows up in the [go race detector](https://ci.appveyor.com/project/fsouza/go-dockerclient/build/6).  This change adds a lock around the `closing` field to remove the race.

Thanks!
Sam
