### PR TITLE
Regenerate zsyscall with latest mksyscall_windows

### DIFF
--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -12,9 +12,9 @@ import (
 var _ unsafe.Pointer
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-	modwinmm    = syscall.NewLazyDLL("winmm.dll")
-	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+	modwinmm    = windows.NewLazySystemDLL("winmm.dll")
+	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
 
 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
 	procCreateIoCompletionPort                               = modkernel32.NewProc("CreateIoCompletionPort")


### PR DESCRIPTION
Use golang 1.7 mksyscall_windows.go to regenerate zsyscall.go.

/cc @jhowardmsft @jstarks 

Signed-off-by: Darren Stahl <darst@microsoft.com>