### PR TITLE
Flush outgoing content before sending EOF message

### DIFF
--- a/file.go
+++ b/file.go
@@ -219,3 +219,7 @@ func (f *win32File) SetWriteDeadline(t time.Time) error {
 	f.writeDeadline = t
 	return nil
 }
+
+func (f *win32File) Flush() error {
+	return syscall.FlushFileBuffers(f.handle)
+}

--- a/pipe.go
+++ b/pipe.go
@@ -87,7 +87,11 @@ func (f *win32MessageBytePipe) CloseWrite() error {
 	if f.writeClosed {
 		return errPipeWriteClosed
 	}
-	_, err := f.win32File.Write(nil)
+	err := f.win32File.Flush()
+	if err != nil {
+		return err
+	}
+	_, err = f.win32File.Write(nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #42 

This adds a `Flush()` method on `win32File`, and calls it on `CloseWrite()` just before sending the 0-length EOF message.

This makes sure that the 0-length message is not collapsed into the previous message, and that functions like io.Copy() do correctly receive an io.EOF error and completes instead of hanging.

The first commit introduces a test that hangs, the second fixes the issue (and makes the test pass)

This was identified, qualified and fixed by @dgageot and me