### PR TITLE
Fix nil pointer dereference on pipe close

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -275,8 +275,8 @@ func (l *win32PipeListener) listenerRoutine() {
 				case <-l.closeCh:
 					// Abort the connect request by closing the handle.
 					p.Close()
-					p = nil
 					err = <-ch
+					p = nil
 					if err == nil || err == ErrFileClosed {
 						err = ErrPipeListenerClosed
 					}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/go-winio/issues/44

We don't nil the file pointer until after the connectPipe() function returns.