### PR TITLE
Don't increment the wait count if the file is closing

### DIFF
--- a/file.go
+++ b/file.go
@@ -127,10 +127,10 @@ func (f *win32File) Close() error {
 // prepareIo prepares for a new IO operation.
 // The caller must call f.wg.Done() when the IO is finished, prior to Close() returning.
 func (f *win32File) prepareIo() (*ioOperation, error) {
-	f.wg.Add(1)
 	if f.closing {
 		return nil, ErrFileClosed
 	}
+	f.wg.Add(1)
 	c := &ioOperation{}
 	c.ch = make(chan ioResult)
 	return c, nil


### PR DESCRIPTION
This prevent a deadlock if `prepareIo()` is called on a closing file as
`Done()` would never been called afterwards.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>