### PR TITLE
Prevent adding to a sync.WaitGroup that has a waiter

### DIFF
--- a/pipe_test.go
+++ b/pipe_test.go
@@ -367,11 +367,11 @@ func TestEchoWithMessaging(t *testing.T) {
 		OutputBufferSize: 65536,
 	}
 	l, err := ListenPipe(testPipeName, &c)
-
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer l.Close()
+
 	listenerDone := make(chan bool)
 	clientDone := make(chan bool)
 	go func() {
@@ -380,6 +380,8 @@ func TestEchoWithMessaging(t *testing.T) {
 		if e != nil {
 			t.Fatal(e)
 		}
+		defer conn.Close()
+
 		time.Sleep(500 * time.Millisecond) // make *sure* we don't begin to read before eof signal is sent
 		io.Copy(conn, conn)
 		conn.(CloseWriter).CloseWrite()


### PR DESCRIPTION
fixes https://github.com/Microsoft/go-winio/issues/29

Go does not allow adding to a sync.WaitGroup that currently has a waiter. This added lock prevents the (rare) case that it happens.

This PR also includes a small test bug fix that was found while working on this issue.

There is no test because the repro conditions are very unreliable, and the test I've been using takes 30s to run (10 times that of the entire current test suite) and only catches it in the race detector at that.

@jstarks 