### PR TITLE
Remove work-around for go 1.6 performance issue (forcing Windows timer to 1ms), improve battery life

### DIFF
--- a/file.go
+++ b/file.go
@@ -16,7 +16,6 @@ import (
 //sys createIoCompletionPort(file syscall.Handle, port syscall.Handle, key uintptr, threadCount uint32) (newport syscall.Handle, err error) = CreateIoCompletionPort
 //sys getQueuedCompletionStatus(port syscall.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) = GetQueuedCompletionStatus
 //sys setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err error) = SetFileCompletionNotificationModes
-//sys timeBeginPeriod(period uint32) (n int32) = winmm.timeBeginPeriod
 
 type atomicBool int32
 
@@ -153,8 +152,6 @@ func (f *win32File) prepareIo() (*ioOperation, error) {
 
 // ioCompletionProcessor processes completed async IOs forever
 func ioCompletionProcessor(h syscall.Handle) {
-	// Set the timer resolution to 1. This fixes a performance regression in golang 1.6.
-	timeBeginPeriod(1)
 	for {
 		var bytes uint32
 		var key uintptr

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -45,7 +45,6 @@ var (
 	procCreateIoCompletionPort                               = modkernel32.NewProc("CreateIoCompletionPort")
 	procGetQueuedCompletionStatus                            = modkernel32.NewProc("GetQueuedCompletionStatus")
 	procSetFileCompletionNotificationModes                   = modkernel32.NewProc("SetFileCompletionNotificationModes")
-	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
 	procCreateFileW                                          = modkernel32.NewProc("CreateFileW")
@@ -119,12 +118,6 @@ func setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err erro
 			err = syscall.EINVAL
 		}
 	}
-	return
-}
-
-func timeBeginPeriod(period uint32) (n int32) {
-	r0, _, _ := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
-	n = int32(r0)
 	return
 }
 


### PR DESCRIPTION
This pull requests reverts changes introduced by #12 and #13. Reasons for doing so:
- go-winio forces the Windows timer to 1ms resolution, which has a significant impact on battery life, as well as causes noticeable CPU utilization for virtual machines. 
- This forcing of the Windows timer to 1ms resolution was done to work around an issue pertaining _only_ to Go 1.6 (#12 and #13), however go-winio no longer builds on Go 1.6. 
- go-winio's forcing of the high-resolution timer defeats improvements to Windows timer handling introduced in Go 1.9.

Background:
- Go 1.6 removed a call that set the Windows timer to 1ms resolution (timeBeginPeriod(1)). https://golang.org/doc/go1.6 :
> On Windows, Go programs in Go 1.5 and earlier forced the global Windows timer resolution to 1ms at startup by calling timeBeginPeriod(1). Go no longer needs this for good scheduler performance, and changing the global timer resolution caused problems on some systems, so the call has been removed.
- This negatively affected performance of go-winio, so #12 and #13 were introduced as a workaround to set the timer resolution to 1ms. 
- Go 1.7 returned to the behavior of Go 1.5, and once again set the timer to 1ms resolution. https://golang.org/doc/go1.7 :
> On Windows, Go programs in Go 1.5 and earlier forced the global Windows timer resolution to 1ms at startup by calling timeBeginPeriod(1). Changing the global timer resolution caused problems on some systems, and testing suggested that the call was not needed for good scheduler performance, so Go 1.6 removed the call. Go 1.7 brings the call back: under some workloads the call is still needed for good scheduler performance.
- Go 1.9 further refined the behavior https://golang.org/doc/go1.9:
> On Windows, Go no longer forces the system timer to run at high resolution when the program is idle. This should reduce the impact of Go programs on battery life.

In a Windows 8.1 guest in VMWare Fusion, I see a ~25% difference in the host process CPU utilization before/after this patch. Given that Go 1.9 is already handling the Windows timer resolution, there has been no noticeable change in the performance of my named-pipe code.