### PR TITLE
Remove workaround to perf issues in go1.6

### DIFF
--- a/file.go
+++ b/file.go
@@ -16,7 +16,6 @@ import (
 //sys createIoCompletionPort(file syscall.Handle, port syscall.Handle, key uintptr, threadCount uint32) (newport syscall.Handle, err error) = CreateIoCompletionPort
 //sys getQueuedCompletionStatus(port syscall.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) = GetQueuedCompletionStatus
 //sys setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err error) = SetFileCompletionNotificationModes
-//sys timeBeginPeriod(period uint32) (n int32) = winmm.timeBeginPeriod
 
 type atomicBool int32
 
@@ -153,8 +152,6 @@ func (f *win32File) prepareIo() (*ioOperation, error) {
 
 // ioCompletionProcessor processes completed async IOs forever
 func ioCompletionProcessor(h syscall.Handle) {
-	// Set the timer resolution to 1. This fixes a performance regression in golang 1.6.
-	timeBeginPeriod(1)
 	for {
 		var bytes uint32
 		var key uintptr

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -38,14 +38,12 @@ func errnoErr(e syscall.Errno) error {
 
 var (
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
-	modwinmm    = windows.NewLazySystemDLL("winmm.dll")
 	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
 
 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
 	procCreateIoCompletionPort                               = modkernel32.NewProc("CreateIoCompletionPort")
 	procGetQueuedCompletionStatus                            = modkernel32.NewProc("GetQueuedCompletionStatus")
 	procSetFileCompletionNotificationModes                   = modkernel32.NewProc("SetFileCompletionNotificationModes")
-	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
 	procCreateFileW                                          = modkernel32.NewProc("CreateFileW")
@@ -119,12 +117,6 @@ func setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err erro
 			err = syscall.EINVAL
 		}
 	}
-	return
-}
-
-func timeBeginPeriod(period uint32) (n int32) {
-	r0, _, _ := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
-	n = int32(r0)
 	return
 }
 


### PR DESCRIPTION
Starting in go1.9, Golang lowers the timer frequency when not required reducing CPU usage. The fix to a perf regression in #12 and #13 was a workaround that prevents Golang from doing so. This PR removes the workaround, since the initial issue was fixed. I see no perf regressions in the test suite.

This does not need to be conditional based on Golang verison, as the issue being worked around was only in go1.6, which is no longer supported by go-winio.

Fixes https://github.com/Microsoft/go-winio/issues/69

Signed-off-by: Darren Stahl <darst@microsoft.com>
  