### PR TITLE
Allow for message pipes in message readmode for Windows named pipes to work.

### DIFF
--- a/file.go
+++ b/file.go
@@ -229,6 +229,9 @@ func (f *win32File) Read(b []byte) (int, error) {
 		return 0, io.EOF
 	} else if err == syscall.ERROR_BROKEN_PIPE {
 		return 0, io.EOF
+	// When there is more data in the message pipe to read, we get ERROR_MORE_DATA. We ignore that error and proceed to read more data
+	} else if err == syscall.ERROR_MORE_DATA && n != 0 && len(b) != 0 {
+		return n, nil
 	} else {
 		return n, err
 	}

--- a/pipe.go
+++ b/pipe.go
@@ -181,9 +181,12 @@ func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
 		return nil, err
 	}
 
-	if state&cPIPE_READMODE_MESSAGE != 0 {
+	/**
+	Windows support message type pipes in message-read mode only. Removing this check to allow for windows named pipes.
+	*/
+	/*if state&cPIPE_READMODE_MESSAGE != 0 {
 		return nil, &os.PathError{Op: "open", Path: path, Err: errors.New("message readmode pipes not supported")}
-	}
+	}*/
 
 	f, err := makeWin32File(h)
 	if err != nil {


### PR DESCRIPTION
Reference: https://github.com/moby/moby/issues/36562#issuecomment-372347544 

The named pipe in Windows is of message type and the handle to the pipe is in message read mode. Removing the check to allow for Windows named pipes to work. 