### PR TITLE
provide access to underlying file handle

### DIFF
--- a/file.go
+++ b/file.go
@@ -265,6 +265,10 @@ func (f *win32File) Flush() error {
 	return syscall.FlushFileBuffers(f.handle)
 }
 
+func (f *win32File) Fd() uintptr {
+	return uintptr(f.handle)
+}
+
 func (d *deadlineHandler) set(deadline time.Time) error {
 	d.setLock.Lock()
 	defer d.setLock.Unlock()


### PR DESCRIPTION
It is convenient to be able to pull off the underlying file handle to pass to other Win32 functions that aren't supported by this library.

This change adds an `Fd() uintptr` method to the file implementation (matches the os.File method of the same name).