### PR TITLE
treat ErrFileClosed as EOF on Read()

### DIFF
--- a/file.go
+++ b/file.go
@@ -227,7 +227,7 @@ func (f *win32File) Read(b []byte) (int, error) {
 	// Handle EOF conditions.
 	if err == nil && n == 0 && len(b) != 0 {
 		return 0, io.EOF
-	} else if err == syscall.ERROR_BROKEN_PIPE {
+	} else if err == syscall.ERROR_BROKEN_PIPE || err == ErrFileClosed {
 		return 0, io.EOF
 	} else {
 		return n, err


### PR DESCRIPTION
An async waiting read can return ErrFileClosed if the pipe is closed on another gofunc. This changes it to be considered an EOF condition instead.
@maxtaco @akalin