### PR TITLE
add badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # go-winio
 
+[![api docs](https://img.shields.io/badge/api-reference-blue.svg)](https://gowalker.org/github.com/Microsoft/go-winio)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Microsoft/go-winio)](https://goreportcard.com/report/github.com/Microsoft/go-winio)
+
 This repository contains utilities for efficiently performing Win32 IO operations in
 Go. Currently, this is focused on accessing named pipes and other file handles, and
 for using named pipes as a net transport.


### PR DESCRIPTION
I find it helpful to have a link to a project's API documentation. Although godoc.org doesn't do a great job rendering Windows-only API, gowalker.org does a pretty good job.

It's also nice to include a Go Report status too. Although only a handful of Microsoft Go projects include one, I decided to add it after discover that azure-sdk-for-go was one that does.