### PR TITLE
make some tests run faster by removing time.Sleeps and modifying implementation

### DIFF
--- a/pipe_test.go
+++ b/pipe_test.go
@@ -260,8 +260,10 @@ func TestDialTimesOutByDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer l.Close()
-	_, err = DialPipe(testPipeName, nil)
-	if err != ErrTimeout {
+	start := time.Now()
+	timeout := time.Millisecond
+	_, err = DialPipe(testPipeName, &timeout)
+	if err != ErrTimeout || time.Since(start) < time.Millisecond {
 		t.Fatalf("expected ErrTimeout, got %v", err)
 	}
 }
@@ -274,14 +276,15 @@ func TestTimeoutPendingRead(t *testing.T) {
 	defer l.Close()
 
 	serverDone := make(chan struct{})
-
+	isReading := make(chan struct{})
 	go func() {
 		s, err := l.Accept()
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(1 * time.Second)
 		s.Close()
+		isReading <- struct{}{}
+
 		close(serverDone)
 	}()
 
@@ -294,11 +297,10 @@ func TestTimeoutPendingRead(t *testing.T) {
 	clientErr := make(chan error)
 	go func() {
 		buf := make([]byte, 10)
+		<-isReading
 		_, err = client.Read(buf)
 		clientErr <- err
 	}()
-
-	time.Sleep(100 * time.Millisecond) // make *sure* the pipe is reading before we set the deadline
 	client.SetReadDeadline(aLongTimeAgo)
 
 	select {
@@ -322,12 +324,14 @@ func TestTimeoutPendingWrite(t *testing.T) {
 
 	serverDone := make(chan struct{})
 
+	isReading := make(chan struct{})
+	wrote := make(chan struct{})
 	go func() {
 		s, err := l.Accept()
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(1 * time.Second)
+		isReading <- struct{}{}
 		s.Close()
 		close(serverDone)
 	}()
@@ -340,12 +344,14 @@ func TestTimeoutPendingWrite(t *testing.T) {
 
 	clientErr := make(chan error)
 	go func() {
+		<-isReading // allow it to close
 		_, err = client.Write([]byte("this should timeout"))
+		wrote <- struct{}{}
 		clientErr <- err
 	}()
 
-	time.Sleep(100 * time.Millisecond) // make *sure* the pipe is writing before we set the deadline
 	client.SetWriteDeadline(aLongTimeAgo)
+	<-wrote
 
 	select {
 	case err = <-clientErr:
@@ -385,12 +391,12 @@ func TestEchoWithMessaging(t *testing.T) {
 		}
 		defer conn.Close()
 
-		time.Sleep(500 * time.Millisecond) // make *sure* we don't begin to read before eof signal is sent
+		time.Sleep(200 * time.Millisecond) // make *sure* we don't begin to read before eof signal is sent
 		io.Copy(conn, conn)
 		conn.(CloseWriter).CloseWrite()
 		close(listenerDone)
 	}()
-	timeout := 1 * time.Second
+	timeout := 500 * time.Second
 	client, err := DialPipe(testPipeName, &timeout)
 	if err != nil {
 		t.Fatal(err)
@@ -446,13 +452,20 @@ func TestConnectRace(t *testing.T) {
 		}
 	}()
 
+	// Dial all in background
+	var wg sync.WaitGroup
 	for i := 0; i < 1000; i++ {
-		c, err := DialPipe(testPipeName, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		c.Close()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := DialPipe(testPipeName, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.Close()
+		}()
 	}
+	wg.Wait() // wait for all to finish
 }
 
 func TestMessageReadMode(t *testing.T) {


### PR DESCRIPTION
Hello!

I made some modifications to pipe_test.go so we use channels to signal we have closed/we are not ready anymore (timing out).

I hope this is a correct implementation as some tests are flaky (i.e. even with incorrect changes they seemed to be passing).

Thanks!