### PR TITLE
Set ETW provider info so it's always treated as TraceLogging

### DIFF
--- a/internal/etw/etw.go
+++ b/internal/etw/etw.go
@@ -12,3 +12,4 @@ package etw
 //sys eventRegister(providerId *windows.GUID, callback uintptr, callbackContext uintptr, providerHandle *providerHandle) (win32err error) = advapi32.EventRegister
 //sys eventUnregister(providerHandle providerHandle) (win32err error) = advapi32.EventUnregister
 //sys eventWriteTransfer(providerHandle providerHandle, descriptor *EventDescriptor, activityID *windows.GUID, relatedActivityID *windows.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
+//sys eventSetInformation(providerHandle providerHandle, class eventInfoClass, information uintptr, length uint32) (win32err error) = advapi32.EventSetInformation

--- a/internal/etw/eventopt.go
+++ b/internal/etw/eventopt.go
@@ -36,6 +36,12 @@ func WithKeyword(keyword uint64) EventOpt {
 	}
 }
 
+func WithChannel(channel Channel) EventOpt {
+	return func(options *eventOptions) {
+		options.descriptor.Channel = channel
+	}
+}
+
 // WithTags specifies the tags of the event to be written. Tags is a 28-bit
 // value (top 4 bits are ignored) which are interpreted by the event consumer.
 func WithTags(newTags uint32) EventOpt {

--- a/internal/etw/provider.go
+++ b/internal/etw/provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"strings"
 	"unicode/utf16"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -39,6 +40,15 @@ const (
 	// ProviderStateCaptureState indicates the provider is having its current
 	// state snap-shotted.
 	ProviderStateCaptureState
+)
+
+type eventInfoClass uint32
+
+const (
+	eventInfoClassProviderBinaryTrackInfo eventInfoClass = iota
+	eventInfoClassProviderSetReserved1
+	eventInfoClassProviderSetTraits
+	eventInfoClassProviderUseDescriptorType
 )
 
 // EnableCallback is the form of the callback function that receives provider
@@ -132,6 +142,15 @@ func NewProviderWithID(name string, id *windows.GUID, callback EnableCallback) (
 	metadata.WriteByte(0)                                                   // Null terminator for name
 	binary.LittleEndian.PutUint16(metadata.Bytes(), uint16(metadata.Len())) // Update the size at the beginning of the buffer
 	provider.metadata = metadata.Bytes()
+
+	if err := eventSetInformation(
+		provider.handle,
+		eventInfoClassProviderSetTraits,
+		uintptr(unsafe.Pointer(&provider.metadata[0])),
+		uint32(len(provider.metadata))); err != nil {
+
+		return nil, err
+	}
 
 	return provider, nil
 }


### PR DESCRIPTION
It turns out ETW only knew to parse our events as TraceLogging previously because they were set to the known TraceLogging channel (11). If you changed the event channel the event was not parsed correctly. This change tells ETW (via EventSetInformation with EventProviderSetTraits) that the provider uses TraceLogging, so events can be parsed even if the channel is changed.

Signed-off-by: Kevin Parsons <kevpar@ntdev.microsoft.com>