### PR TITLE
Add OpenVirtualDisk to vhd library

### DIFF
--- a/vhd/zvhd.go
+++ b/vhd/zvhd.go
@@ -65,7 +65,7 @@ func _createVirtualDisk(virtualStorageType *virtualStorageType, path *uint16, vi
 	return
 }
 
-func openVirtualDisk(virtualStorageType *virtualStorageType, path string, virtualDiskAccessMask uint32, flags uint32, parameters *uintptr, handle *syscall.Handle) (err error) {
+func openVirtualDisk(virtualStorageType *virtualStorageType, path string, virtualDiskAccessMask uint32, flags uint32, parameters *openVirtualDiskParameters, handle *syscall.Handle) (err error) {
 	var _p0 *uint16
 	_p0, err = syscall.UTF16PtrFromString(path)
 	if err != nil {
@@ -74,7 +74,7 @@ func openVirtualDisk(virtualStorageType *virtualStorageType, path string, virtua
 	return _openVirtualDisk(virtualStorageType, _p0, virtualDiskAccessMask, flags, parameters, handle)
 }
 
-func _openVirtualDisk(virtualStorageType *virtualStorageType, path *uint16, virtualDiskAccessMask uint32, flags uint32, parameters *uintptr, handle *syscall.Handle) (err error) {
+func _openVirtualDisk(virtualStorageType *virtualStorageType, path *uint16, virtualDiskAccessMask uint32, flags uint32, parameters *openVirtualDiskParameters, handle *syscall.Handle) (err error) {
 	r1, _, e1 := syscall.Syscall6(procOpenVirtualDisk.Addr(), 6, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(flags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(handle)))
 	if r1 != 0 {
 		if e1 != 0 {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>'

@jterry75 Hold fire merging until I've got the end to end validation complete.

This adds `OpenVirtualDisk` to the library. I'm working from the bottom up of this VHD disabling flushing on v2 issue/optimization. In order to send the required IOCTLs, I need a handle to the scratch VHD. Mirrors same functionality in the Windows Orchestrator. 