### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/vhd/mksyscall_windows.go
+++ b/vhd/mksyscall_windows.go
@@ -468,7 +468,7 @@ func (f *Fn) DLLName() string {
 	return f.dllname
 }
 
-// DLLName returns DLL function name for function f.
+// DLLFuncName returns DLL function name for function f.
 func (f *Fn) DLLFuncName() string {
 	if f.dllfuncname == "" {
 		return f.Name


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?