### PR TITLE
add DialPipeContext

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -138,7 +138,7 @@ func (s pipeAddress) String() string {
 	return string(s)
 }
 
-//helper function used to try to open the pipe multiple times.
+// tryDialPipe attempts to dial the pipe at `path` until `ctx` cancellation or timeout.
 func tryDialPipe(ctx context.Context, path *string) (syscall.Handle, error) {
 	for {
 		select {
@@ -150,7 +150,7 @@ func tryDialPipe(ctx context.Context, path *string) (syscall.Handle, error) {
 				return h, nil
 			}
 			if err != cERROR_PIPE_BUSY {
-				return h, newOpenError(path, err)
+				return h, &os.PathError{Err: err, Op: "open", Path: *path}
 			}
 			// Wait 10 msec and try again. This is a rather simplistic
 			// view, as we always try each 10 milliseconds.
@@ -184,8 +184,8 @@ func newOpenError(path *string, err error) error {
 	return nil
 }
 
-//DialPipeContext connects to a named pipe. ctx can be used to cancel or
-//expire the pending connection ( We do not use WaitNamedPipe.)
+// DialPipeContext attempts to connect to a named pipe by `path` until `ctx`
+// cancellation or timeout.
 func DialPipeContext(ctx context.Context, path string) (net.Conn, error) {
 	var err error
 	var h syscall.Handle

--- a/pipe.go
+++ b/pipe.go
@@ -177,13 +177,6 @@ func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
 	return conn, err
 }
 
-func newOpenError(path *string, err error) error {
-	if err != nil {
-		return &os.PathError{Err: err, Op: "open", Path: *path}
-	}
-	return nil
-}
-
 // DialPipeContext attempts to connect to a named pipe by `path` until `ctx`
 // cancellation or timeout.
 func DialPipeContext(ctx context.Context, path string) (net.Conn, error) {

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -38,6 +38,20 @@ func TestDialListenerTimesOut(t *testing.T) {
 	}
 }
 
+func TestDialContextListenerTimesOut(t *testing.T) {
+	l, err := ListenPipe(testPipeName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	var d = time.Duration(10 * time.Millisecond)
+	ctx, _ := context.WithTimeout(context.Background(), d)
+	_, err = DialPipeContext(ctx, testPipeName)
+	if err != context.DeadlineExceeded {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
 func TestDialListenerGetsCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	l, err := ListenPipe(testPipeName, nil)

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -53,8 +53,8 @@ func TestDialListenerGetsCancelled(t *testing.T) {
 	time.Sleep(time.Millisecond * 30)
 	cancel()
 	err = <-ch
-	if err == nil {
-		t.Fatalf("expected ErrTimeout, got %v", err)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
 


### PR DESCRIPTION
This adds the DialPipeContext function, providing a way to expire or cancel pending pipe connections using a context.Context.