### PR TITLE
pkg/etw: Add support for time.Time

### DIFF
--- a/pkg/etw/eventdata.go
+++ b/pkg/etw/eventdata.go
@@ -3,6 +3,7 @@ package etw
 import (
 	"bytes"
 	"encoding/binary"
+	"syscall"
 )
 
 // eventData maintains a buffer which builds up the data for an ETW event. It
@@ -61,5 +62,10 @@ func (ed *eventData) writeUint32(value uint32) {
 
 // writeUint64 appends a uint64 to the buffer.
 func (ed *eventData) writeUint64(value uint64) {
+	binary.Write(&ed.buffer, binary.LittleEndian, value)
+}
+
+// writeFiletime appends a FILETIME to the buffer.
+func (ed *eventData) writeFiletime(value syscall.Filetime) {
 	binary.Write(&ed.buffer, binary.LittleEndian, value)
 }


### PR DESCRIPTION
This change adds support for encoding time.Time values as FILETIME
values in tracelogging events. FILETIME has slightly less precision than
time.Time (100ns vs 1ns), but it is the closest availble match.