### PR TITLE
Updates the error message in GetFileSystemType

### DIFF
--- a/pkg/fs/fs_windows.go
+++ b/pkg/fs/fs_windows.go
@@ -9,12 +9,17 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var (
+	// ErrInvalidPath is returned when the location of a file path doesn't begin with a driver letter.
+	ErrInvalidPath = errors.New("the path provided to GetFileSystemType must start with a drive letter")
+)
+
 // GetFileSystemType obtains the type of a file system through GetVolumeInformation.
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364993(v=vs.85).aspx
 func GetFileSystemType(path string) (fsType string, hr error) {
 	drive := filepath.VolumeName(path)
 	if len(drive) != 2 {
-		return "", errors.New("getFileSystemType path must start with a drive letter")
+		return "", ErrInvalidPath
 	}
 
 	var (


### PR DESCRIPTION
This PR updates the error message in GetFileSystemType to match the function's casing and exports the error. Since I searched for this case-sensitive I ended up not being able to find it earlier; Go lint will complain if we use caps in the `errors.New` at the beginning, so I changed the content slightly.

Open to suggestions for naming/error description.

Signed-off-by: Eric Hotinger <ehotinger@gmail.com>