### PR TITLE
lowercase module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Microsoft/go-winio
+module github.com/microsoft/go-winio
 
 go 1.12
 


### PR DESCRIPTION
Breaks builds on non-windows,

`parsing go.mod: unexpected module path "github.com/Microsoft/go-winio"`

Fixes #156 