### PR TITLE
Add a function to Relisten on a pipe

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -429,6 +429,28 @@ type PipeConfig struct {
 	OutputBufferSize int32
 }
 
+// ListenOnlyPipe creates a listener on a Windows named pipe path, e.g. \\.\pipe\mypipe.
+// The pipe must already exist.
+func ListenOnlyPipe(path string, c *PipeConfig) (net.Listener, error) {
+	if c == nil {
+		c = &PipeConfig{}
+	}
+	h, err := makeServerPipeHandle(path, nil, c, false)
+	if err != nil {
+		return nil, err
+	}
+	l := &win32PipeListener{
+		firstHandle: h,
+		path:        path,
+		config:      *c,
+		acceptCh:    make(chan (chan acceptResponse)),
+		closeCh:     make(chan int),
+		doneCh:      make(chan int),
+	}
+	go l.listenerRoutine()
+	return l, nil
+}
+
 // ListenPipe creates a listener on a Windows named pipe path, e.g. \\.\pipe\mypipe.
 // The pipe must not already exist.
 func ListenPipe(path string, c *PipeConfig) (net.Listener, error) {

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -218,6 +218,54 @@ func TestCloseAbortsListen(t *testing.T) {
 	}
 }
 
+func TestMultiListener(t *testing.T) {
+	l1, err := ListenPipe(testPipeName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l1.Close()
+
+	l2, err := ListenOnlyPipe(testPipeName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l2.Close()
+
+	ch1 := make(chan int)
+	go server(l1, ch1)
+
+	ch2 := make(chan int)
+	go server(l2, ch2)
+
+	c, err := DialPipe(testPipeName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	rw := bufio.NewReadWriter(bufio.NewReader(c), bufio.NewWriter(c))
+	_, err = rw.WriteString("hello world\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = rw.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := rw.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := "got hello world\n"
+	if s != ms {
+		t.Errorf("expected '%s', got '%s'", ms, s)
+	}
+
+	<-ch1
+	<-ch2
+}
+
 func ensureEOFOnClose(t *testing.T, r io.Reader, w io.Closer) {
 	b := make([]byte, 10)
 	w.Close()


### PR DESCRIPTION
This adds a method for re-listening on an existing pipe.  Helpful in case where the pipe creator process is restarted and the pipe still exists.  `winio.ListenPipe` fails now if the pipe exists already.