### PR TITLE
Correct GetVolumeInformation return type handling

### DIFF
--- a/pkg/fs/fs_windows_test.go
+++ b/pkg/fs/fs_windows_test.go
@@ -1,0 +1,46 @@
+package fs
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetFSTypeOfKnownDrive(t *testing.T) {
+	fsType, err := GetFileSystemType("C:\\")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fsType == "" {
+		t.Fatal("No filesystem type name returned")
+	}
+}
+
+func TestGetFSTypeOfInvalidPath(t *testing.T) {
+	_, err := GetFileSystemType("7:\\")
+	if err != ErrInvalidPath {
+		t.Fatalf("Expected `ErrInvalidPath`, got %v", err)
+	}
+}
+
+func TestGetFSTypeOfValidButAbsentDrive(t *testing.T) {
+	drive := ""
+	for _, letter := range "abcdefghijklmnopqrstuvwxyz" {
+		possibleDrive := string(letter) + ":\\"
+		if _, err := os.Stat(possibleDrive); os.IsNotExist(err) {
+			drive = possibleDrive
+			break
+		}
+	}
+	if drive == "" {
+		t.Skip("Every possible drive exists")
+	}
+
+	_, err := GetFileSystemType(drive)
+	if err == nil {
+		t.Fatalf("GetFileSystemType %s unexpectedly succeeded", drive)
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("GetFileSystemType %s failed with %v, expected 'ErrNotExist' or similar", drive, err)
+	}
+}


### PR DESCRIPTION
The [docs](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364993(v=vs.85).aspx) say it returns 0 for failure, non-zero for success.

This implementation is looking for <0 as HRESULT failure, and deriving
an Errno from that.

The new tests fail with GetFileSystemType as it was defined, e.g.,
```
--- FAIL: TestGetFSTypeOfValidButAbsentDrive (0.00s)
    fs_windows_test.go:41: GetFileSystemType a:\ unexpectedly succeeded
```
when I definitely do not have an A:\ drive.