### PR TITLE
Remove error if ATTACH_VIRTUAL_DISK_PARAMETERS wasn't version 2

### DIFF
--- a/vhd/vhd.go
+++ b/vhd/vhd.go
@@ -176,9 +176,7 @@ func DetachVhd(path string) error {
 
 // AttachVirtualDisk attaches a virtual hard disk for use.
 func AttachVirtualDisk(handle syscall.Handle, attachVirtualDiskFlag AttachVirtualDiskFlag, parameters *AttachVirtualDiskParameters) (err error) {
-	if parameters.Version != 2 {
-		return fmt.Errorf("only version 2 VHDs are supported, found version: %d", parameters.Version)
-	}
+	// Supports both version 1 and 2 of the attach parameters as version 2 wasn't present in RS5.
 	if err := attachVirtualDisk(
 		handle,
 		nil,
@@ -192,7 +190,8 @@ func AttachVirtualDisk(handle syscall.Handle, attachVirtualDiskFlag AttachVirtua
 	return nil
 }
 
-// AttachVhd attaches a virtual hard disk at `path` for use.
+// AttachVhd attaches a virtual hard disk at `path` for use. Attaches using version 2
+// of the ATTACH_VIRTUAL_DISK_PARAMETERS.
 func AttachVhd(path string) (err error) {
 	handle, err := OpenVirtualDisk(
 		path,


### PR DESCRIPTION
* Version 2 didn't exist in RS5 so it's a bit silly to error out in this case.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>