### PR TITLE
pkg/guid: make code windows-only

### DIFF
--- a/pkg/guid/doc.go
+++ b/pkg/guid/doc.go
@@ -1,0 +1,7 @@
+// Package guid provides a GUID type. The backing structure for a GUID is
+// identical to that used by the golang.org/x/sys/windows GUID type.
+// There are two main binary encodings used for a GUID, the big-endian encoding,
+// and the Windows (mixed-endian) encoding. See here for details:
+// https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding
+
+package guid

--- a/pkg/guid/guid.go
+++ b/pkg/guid/guid.go
@@ -1,8 +1,5 @@
-// Package guid provides a GUID type. The backing structure for a GUID is
-// identical to that used by the golang.org/x/sys/windows GUID type.
-// There are two main binary encodings used for a GUID, the big-endian encoding,
-// and the Windows (mixed-endian) encoding. See here for details:
-// https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding
+//+build windows
+
 package guid
 
 import (

--- a/pkg/guid/guid_test.go
+++ b/pkg/guid/guid_test.go
@@ -1,3 +1,5 @@
+//+build windows
+
 package guid
 
 import (


### PR DESCRIPTION
relates to https://github.com/microsoft/hcsshim/pull/941#issuecomment-775469484 and https://github.com/microsoft/hcsshim/pull/942

When attempting to update go modules in a project, "go get" failed, because the pkg/guid package contained Windows-only code, but was not marked as "windows-only", resulting in the following error:

    GO111MODULE=on go get github.com/Microsoft/hcsshim@v0.8.14
    ....
    package github.com/Microsoft/hcsshim
        imports github.com/Microsoft/go-winio/pkg/guid
        imports golang.org/x/sys/windows: build constraints exclude all Go files in /go/pkg/mod/golang.org/x/sys@v0.0.0-20201201145000-ef89a241ccb3/windows

This patch marks the code as "windows-only", excluding it from other platforms. A "doc.go" file was added so that the package is not considered "empty" on other platforms.

