### PR TITLE
Use golang.org/x/sys/execabs instead of os/exec

### DIFF
--- a/pkg/security/grantvmgroupaccess_test.go
+++ b/pkg/security/grantvmgroupaccess_test.go
@@ -3,11 +3,12 @@ package security
 import (
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // TestGrantVmGroupAccess verifies for the three case of a file, a directory,


### PR DESCRIPTION
~This is a follow-up to https://github.com/microsoft/go-winio/pull/194, which updates golang.org/x/sys~ merged

On Windows, the os/exec.{Command,CommandContext,LookPath} functions resolve command names that have neither path separators nor file extension (e.g., "git") by first looking in the current working directory before looking in the PATH environment variable.
Go maintainers intended to match cmd.exe's historical behavior.

However, this is pretty much never the intended behavior and as an abundance of precaution this patch prevents that when executing commands.

This patch was prompted by the [Go 1.15.7 security fixes](https://blog.golang.org/path-security).