### PR TITLE
pkg/etw: Fix to build on windows/arm

### DIFF
--- a/pkg/etw/newprovider.go
+++ b/pkg/etw/newprovider.go
@@ -12,46 +12,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-type providerOpts struct {
-	callback EnableCallback
-	id       guid.GUID
-	group    guid.GUID
-}
-
-// ProviderOpt allows the caller to specify provider options to
-// NewProviderWithOptions
-type ProviderOpt func(*providerOpts)
-
-// WithCallback is used to provide a callback option to NewProviderWithOptions
-func WithCallback(callback EnableCallback) ProviderOpt {
-	return func(opts *providerOpts) {
-		opts.callback = callback
-	}
-}
-
-// WithID is used to provide a provider ID option to NewProviderWithOptions
-func WithID(id guid.GUID) ProviderOpt {
-	return func(opts *providerOpts) {
-		opts.id = id
-	}
-}
-
-// WithGroup is used to provide a provider group option to
-// NewProviderWithOptions
-func WithGroup(group guid.GUID) ProviderOpt {
-	return func(opts *providerOpts) {
-		opts.group = group
-	}
-}
-
-// NewProviderWithID creates and registers a new ETW provider, allowing the
-// provider ID to be manually specified. This is most useful when there is an
-// existing provider ID that must be used to conform to existing diagnostic
-// infrastructure.
-func NewProviderWithID(name string, id guid.GUID, callback EnableCallback) (provider *Provider, err error) {
-	return NewProviderWithOptions(name, WithID(id), WithCallback(callback))
-}
-
 // NewProviderWithOptions creates and registers a new ETW provider, allowing
 // the provider ID and Group to be manually specified. This is most useful when
 // there is an existing provider ID that must be used to conform to existing

--- a/pkg/etw/newprovider_unsupported.go
+++ b/pkg/etw/newprovider_unsupported.go
@@ -3,11 +3,7 @@
 
 package etw
 
-import (
-	"github.com/Microsoft/go-winio/pkg/guid"
-)
-
 // NewProviderWithID returns a nil provider on unsupported platforms.
-func NewProviderWithID(name string, id guid.GUID, callback EnableCallback) (provider *Provider, err error) {
+func NewProviderWithOptions(name string, options ...ProviderOpt) (provider *Provider, err error) {
 	return nil, nil
 }

--- a/pkg/etw/provider.go
+++ b/pkg/etw/provider.go
@@ -119,6 +119,46 @@ func providerIDFromName(name string) guid.GUID {
 	return guid.FromWindowsArray(a)
 }
 
+type providerOpts struct {
+	callback EnableCallback
+	id       guid.GUID
+	group    guid.GUID
+}
+
+// ProviderOpt allows the caller to specify provider options to
+// NewProviderWithOptions
+type ProviderOpt func(*providerOpts)
+
+// WithCallback is used to provide a callback option to NewProviderWithOptions
+func WithCallback(callback EnableCallback) ProviderOpt {
+	return func(opts *providerOpts) {
+		opts.callback = callback
+	}
+}
+
+// WithID is used to provide a provider ID option to NewProviderWithOptions
+func WithID(id guid.GUID) ProviderOpt {
+	return func(opts *providerOpts) {
+		opts.id = id
+	}
+}
+
+// WithGroup is used to provide a provider group option to
+// NewProviderWithOptions
+func WithGroup(group guid.GUID) ProviderOpt {
+	return func(opts *providerOpts) {
+		opts.group = group
+	}
+}
+
+// NewProviderWithID creates and registers a new ETW provider, allowing the
+// provider ID to be manually specified. This is most useful when there is an
+// existing provider ID that must be used to conform to existing diagnostic
+// infrastructure.
+func NewProviderWithID(name string, id guid.GUID, callback EnableCallback) (provider *Provider, err error) {
+	return NewProviderWithOptions(name, WithID(id), WithCallback(callback))
+}
+
 // NewProvider creates and registers a new ETW provider. The provider ID is
 // generated based on the provider name.
 func NewProvider(name string, callback EnableCallback) (provider *Provider, err error) {


### PR DESCRIPTION
We don't support actually using ETW on windows/arm, but to make things
easier for downstream dependencies, we want to still allow the package
to compile and just no-op on this architecture. We do this by returning
a nil Provider, and implementing its methods to no-op when the receiver
is nil.

Previously this was implemented by putting NewProviderWithID in
provider_unsupported.go, but when we refactored the code so that the
actual work was done in NewProviderWithOptions instead, we didn't fix up
provider_unsupported. This change fixes this by putting only
NewProviderWithOptions in provider_unsupported.go, since the other
provider creation functions call into this one.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>