### PR TITLE
Add security privilege (needed for VHDX support for docker data root)

### DIFF
--- a/privilege.go
+++ b/privilege.go
@@ -28,8 +28,9 @@ const (
 
 	ERROR_NOT_ALL_ASSIGNED syscall.Errno = 1300
 
-	SeBackupPrivilege  = "SeBackupPrivilege"
-	SeRestorePrivilege = "SeRestorePrivilege"
+	SeBackupPrivilege   = "SeBackupPrivilege"
+	SeRestorePrivilege  = "SeRestorePrivilege"
+	SeSecurityPrivilege = "SeSecurityPrivilege"
 )
 
 const (


### PR DESCRIPTION
To support using VHDX for the Docker data root and the writing of image layers an additional privilege is needed.  Added "SeSecurityPrivilege" as an additional option.

Microsoft Case#120082125001494
Signed-off-by: Adam Williams <awilliams@mirantis.com>