### PR TITLE
Build the three binaries in this repo from the ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,24 @@
-name: CI 
+name: CI
 on:
   - push
   - pull_request
 
-jobs: 
+jobs:
   test:
     runs-on: 'windows-2019'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
       - run: go test -gcflags=all=-d=checkptr -v ./...
+
+  build:
+    runs-on: 'windows-2019'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.0'
+
+      - run: go build ./pkg/etw/sample/
+      - run: go build ./tools/etw-provider-gen/
+      - run: go build ./wim/validate/


### PR DESCRIPTION
Even though this repo is normally used as a dependency, there are some sample binaries and tools built out of here. This just makes sure they still build after changes 

Signed-off-by: Daniel Canter <dcanter@microsoft.com>