### PR TITLE
Add etw UnicodeStringField

### DIFF
--- a/pkg/etw/eventdata.go
+++ b/pkg/etw/eventdata.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"syscall"
+	"unicode/utf16"
 )
 
 // eventData maintains a buffer which builds up the data for an ETW event. It
@@ -26,6 +27,13 @@ func (ed *eventData) toBytes() []byte {
 func (ed *eventData) writeString(data string) {
 	_, _ = ed.buffer.WriteString(data)
 	_ = ed.buffer.WriteByte(0)
+}
+
+// writeUnicodeString appends a string converted to UTF-16, including the null terminator, to the buffer.
+func (ed *eventData) writeUnicodeString(data string) {
+	unicode := utf16.Encode([]rune(data))
+	binary.Write(&ed.buffer, binary.LittleEndian, unicode)
+	ed.buffer.Write([]byte{0, 0})
 }
 
 // writeInt8 appends a int8 to the buffer.

--- a/pkg/etw/fieldopt.go
+++ b/pkg/etw/fieldopt.go
@@ -64,6 +64,14 @@ func JSONStringField(name string, value string) FieldOpt {
 	}
 }
 
+// UnicodeStringField adds a single UTF-16 string field to the event.
+func UnicodeStringField(name string, value string) FieldOpt {
+	return func(em *eventMetadata, ed *eventData) {
+		em.writeField(name, inTypeUnicodeString, outTypeString, 0)
+		ed.writeUnicodeString(value)
+	}
+}
+
 // StringArray adds an array of string to the event.
 func StringArray(name string, values []string) FieldOpt {
 	return func(em *eventMetadata, ed *eventData) {
@@ -71,6 +79,17 @@ func StringArray(name string, values []string) FieldOpt {
 		ed.writeUint16(uint16(len(values)))
 		for _, v := range values {
 			ed.writeString(v)
+		}
+	}
+}
+
+// UnicodeStringArray adds an array of UTF-16 strings to the event.
+func UnicodeStringArray(name string, values []string) FieldOpt {
+	return func(em *eventMetadata, ed *eventData) {
+		em.writeArray(name, inTypeUnicodeString, outTypeString, 0)
+		ed.writeUint16(uint16(len(values)))
+		for _, v := range values {
+			ed.writeUnicodeString(v)
 		}
 	}
 }


### PR DESCRIPTION
Allow to send UTF-16 encoded message. It's the only missing part needed for writing messages with local characters into event log via this library, when string is specified as win:UnicodeString in instrumentation manifest (which cannot be changed).

`UnicodeStringArray` is there only for completeness from my point of view.