### PR TITLE
Cleanup wim package for use on non Windows platforms

### DIFF
--- a/wim/decompress.go
+++ b/wim/decompress.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package wim
 
 import (

--- a/wim/validate/noop.go
+++ b/wim/validate/noop.go
@@ -1,5 +1,0 @@
-// +build !windows
-
-package main
-
-func main() {}

--- a/wim/wim.go
+++ b/wim/wim.go
@@ -1,5 +1,3 @@
-// +build windows
-
 // Package wim implements a WIM file parser.
 //
 // WIM files are used to distribute Windows file system and container images.


### PR DESCRIPTION
Cleans up the wim package (removing unnecessary build tag guards), and
cleans up the wim/validate command to be slightly more "Go idiomatic".