### PR TITLE
Fix corruption in x86 callback

### DIFF
--- a/pkg/etw/provider.go
+++ b/pkg/etw/provider.go
@@ -83,15 +83,6 @@ func providerCallback(sourceID guid.GUID, state ProviderState, level Level, matc
 	}
 }
 
-// providerCallbackAdapter acts as the first-level callback from the C/ETW side
-// for provider notifications. Because Go has trouble with callback arguments of
-// different size, it has only pointer-sized arguments, which are then cast to
-// the appropriate types when calling providerCallback.
-func providerCallbackAdapter(sourceID *guid.GUID, state uintptr, level uintptr, matchAnyKeyword uintptr, matchAllKeyword uintptr, filterData uintptr, i uintptr) uintptr {
-	providerCallback(*sourceID, ProviderState(state), Level(level), uint64(matchAnyKeyword), uint64(matchAllKeyword), filterData, i)
-	return 0
-}
-
 // providerIDFromName generates a provider ID based on the provider name. It
 // uses the same algorithm as used by .NET's EventSource class, which is based
 // on RFC 4122. More information on the algorithm can be found here:

--- a/pkg/etw/wrapper_32.go
+++ b/pkg/etw/wrapper_32.go
@@ -4,6 +4,7 @@
 package etw
 
 import (
+	"github.com/Microsoft/go-winio/pkg/guid"
 	"golang.org/x/sys/windows"
 )
 
@@ -49,4 +50,18 @@ func eventSetInformation(
 		class,
 		information,
 		length)
+}
+
+// providerCallbackAdapter acts as the first-level callback from the C/ETW side
+// for provider notifications. Because Go has trouble with callback arguments of
+// different size, it has only pointer-sized arguments, which are then cast to
+// the appropriate types when calling providerCallback.
+// For x86, the matchAny and matchAll keywords need to be assembled from two
+// 32-bit integers, because the max size of an argument is uintptr, but those
+// two arguments are actually 64-bit integers.
+func providerCallbackAdapter(sourceID *guid.GUID, state uint32, level uint8, matchAnyKeyword_low uint32, matchAnyKeyword_high uint32, matchAllKeyword_low uint32, matchAllKeyword_high uint32, filterData uintptr, i uintptr) uintptr {
+	matchAnyKeyword := uint64(matchAnyKeyword_high) << 32 | uint64(matchAnyKeyword_low)
+	matchAllKeyword := uint64(matchAllKeyword_high) << 32 | uint64(matchAllKeyword_low)
+	providerCallback(*sourceID, ProviderState(state), Level(level), uint64(matchAnyKeyword), uint64(matchAllKeyword), filterData, i)
+	return 0
 }

--- a/pkg/etw/wrapper_64.go
+++ b/pkg/etw/wrapper_64.go
@@ -4,6 +4,7 @@
 package etw
 
 import (
+	"github.com/Microsoft/go-winio/pkg/guid"
 	"golang.org/x/sys/windows"
 )
 
@@ -39,4 +40,13 @@ func eventSetInformation(
 		class,
 		information,
 		length)
+}
+
+// providerCallbackAdapter acts as the first-level callback from the C/ETW side
+// for provider notifications. Because Go has trouble with callback arguments of
+// different size, it has only pointer-sized arguments, which are then cast to
+// the appropriate types when calling providerCallback.
+func providerCallbackAdapter(sourceID *guid.GUID, state uint32, level uint8, matchAnyKeyword uintptr, matchAllKeyword uintptr, filterData uintptr, i uintptr) uintptr {
+	providerCallback(*sourceID, ProviderState(state), Level(level), uint64(matchAnyKeyword), uint64(matchAllKeyword), filterData, i)
+	return 0
 }


### PR DESCRIPTION
When running on x86, the provider callback doesn't function correctly because two of the arguments are ULONGLONG's (64-bit), which does not align with the uintptr on x86 (32-bit).

This change splits the function into two platform-specific versions to avoid the issue.