### PR TITLE
Fixing corruption in callbacks introduced by x86 changes

### DIFF
--- a/pkg/etw/sample/sample.go
+++ b/pkg/etw/sample/sample.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/guid"
@@ -18,6 +19,8 @@ func callback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matc
 }
 
 func main() {
+	fmt.Printf("Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
 	group, err := guid.FromString("12341234-abcd-abcd-abcd-123412341234")
 	if err != nil {
 		logrus.Error(err)

--- a/pkg/etw/wrapper_32.go
+++ b/pkg/etw/wrapper_32.go
@@ -59,9 +59,9 @@ func eventSetInformation(
 // For x86, the matchAny and matchAll keywords need to be assembled from two
 // 32-bit integers, because the max size of an argument is uintptr, but those
 // two arguments are actually 64-bit integers.
-func providerCallbackAdapter(sourceID *guid.GUID, state uint32, level uint8, matchAnyKeyword_low uint32, matchAnyKeyword_high uint32, matchAllKeyword_low uint32, matchAllKeyword_high uint32, filterData uintptr, i uintptr) uintptr {
-	matchAnyKeyword := uint64(matchAnyKeyword_high) << 32 | uint64(matchAnyKeyword_low)
-	matchAllKeyword := uint64(matchAllKeyword_high) << 32 | uint64(matchAllKeyword_low)
+func providerCallbackAdapter(sourceID *guid.GUID, state uint32, level uint32, matchAnyKeyword_low uint32, matchAnyKeyword_high uint32, matchAllKeyword_low uint32, matchAllKeyword_high uint32, filterData uintptr, i uintptr) uintptr {
+	matchAnyKeyword := uint64(matchAnyKeyword_high)<<32 | uint64(matchAnyKeyword_low)
+	matchAllKeyword := uint64(matchAllKeyword_high)<<32 | uint64(matchAllKeyword_low)
 	providerCallback(*sourceID, ProviderState(state), Level(level), uint64(matchAnyKeyword), uint64(matchAllKeyword), filterData, i)
 	return 0
 }

--- a/pkg/etw/wrapper_64.go
+++ b/pkg/etw/wrapper_64.go
@@ -46,7 +46,7 @@ func eventSetInformation(
 // for provider notifications. Because Go has trouble with callback arguments of
 // different size, it has only pointer-sized arguments, which are then cast to
 // the appropriate types when calling providerCallback.
-func providerCallbackAdapter(sourceID *guid.GUID, state uint32, level uint8, matchAnyKeyword uintptr, matchAllKeyword uintptr, filterData uintptr, i uintptr) uintptr {
+func providerCallbackAdapter(sourceID *guid.GUID, state uintptr, level uintptr, matchAnyKeyword uintptr, matchAllKeyword uintptr, filterData uintptr, i uintptr) uintptr {
 	providerCallback(*sourceID, ProviderState(state), Level(level), uint64(matchAnyKeyword), uint64(matchAllKeyword), filterData, i)
 	return 0
 }


### PR DESCRIPTION
In [my previous PR](https://github.com/microsoft/go-winio/pull/214), when breaking out providerCallbackAdapter into separate 32 and 64 bit implementations, I changed the typing of the state and level arguments erroneously. These parameters should be treated as pointers, not as raw integers. This issue will cause the parameters passed into providerCallback to be corrupted.

Typically this is benign, however it causes a crash in the following scenario:
- Callbacks are enabled (i.e. someone is listening for the event provider)
- An event provider was previous registered and unregistered in the same executable.

Under these conditions, the global provider map (in providerglobal.go) will not have an entry at index 0 (the index only ever increases, so the previous registering/unregistering of a provider leaves the 0 slot empty). The corrupted arguments into providerCallback will have an index of 0 instead of the correct index, and then providerCallback (provider.go line 69) will get a null provider and then attempt to update its state, causing a null reference panic.

This was missed in my initial testing, because for the test providers nothing is listening for the events, so the callback never gets called.