### PR TITLE
Update README with DCO information + re-order into sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,27 @@ package.
 
 Please see the LICENSE file for licensing information.
 
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/). For more information
-see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
-questions or comments.
+## Contributing
 
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA)
+declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR
+appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+We also require that contributors sign their commits using git commit -s or git commit --signoff to certify they either authored the work themselves
+or otherwise have permission to use it in this project. Please see https://developercertificate.org/ for more info, as well as to make sure that you can
+attest to the rules listed. Our CI uses the DCO Github app to ensure that all commits in a given PR are signed-off.
+
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+
+
+## Special Thanks
 Thanks to natefinch for the inspiration for this library. See https://github.com/natefinch/npipe
 for another named pipe implementation.


### PR DESCRIPTION
This change updates the README to mention that we now require a valid
DCO on every commit via the bot. Also adds a new contributing section
that houses this info.

This change also re-orders the README into sections:
Contributing, Code of Conduct, Special Thanks

Signed-off-by: Daniel Canter <dcanter@microsoft.com>