### PR TITLE
chore: removes unneeded receiver in timeoutError

### DIFF
--- a/file.go
+++ b/file.go
@@ -43,9 +43,9 @@ var (
 
 type timeoutError struct{}
 
-func (e *timeoutError) Error() string   { return "i/o timeout" }
-func (e *timeoutError) Timeout() bool   { return true }
-func (e *timeoutError) Temporary() bool { return true }
+func (*timeoutError) Error() string   { return "i/o timeout" }
+func (*timeoutError) Timeout() bool   { return true }
+func (*timeoutError) Temporary() bool { return true }
 
 type timeoutChan chan struct{}
 


### PR DESCRIPTION
This PR removes receiver names from `timeoutError` as they aren't used.