### PR TITLE
Fix TestLookupEmptyNameFails

### DIFF
--- a/sd_test.go
+++ b/sd_test.go
@@ -20,7 +20,7 @@ func TestLookupValidSid(t *testing.T) {
 }
 
 func TestLookupEmptyNameFails(t *testing.T) {
-	_, err := LookupSidByName(".\\weoifjdsklfj")
+	_, err := LookupSidByName("")
 	aerr, ok := err.(*AccountLookupError)
 	if !ok || aerr.Err != cERROR_NONE_MAPPED {
 		t.Fatalf("expected AccountLookupError with ERROR_NONE_MAPPED, got %s", err)


### PR DESCRIPTION
TestLookupEmptyNameFails was an identical copy of TestLookupInvalidSid
in the same file. This commit changes the account name queried by the
former to an empty string which is what the name of the test case
suggests.