### PR TITLE
Replace github.com/pkg/errors with stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/Microsoft/go-winio
 
-go 1.12
+go 1.13
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vhd/vhd.go
+++ b/vhd/vhd.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
@@ -155,7 +154,7 @@ func CreateVhdx(path string, maxSizeInGb, blockSizeInMb uint32) error {
 // DetachVirtualDisk detaches a virtual hard disk by handle.
 func DetachVirtualDisk(handle syscall.Handle) (err error) {
 	if err := detachVirtualDisk(handle, 0, 0); err != nil {
-		return errors.Wrap(err, "failed to detach virtual disk")
+		return fmt.Errorf("failed to detach virtual disk: %w", err)
 	}
 	return nil
 }
@@ -185,7 +184,7 @@ func AttachVirtualDisk(handle syscall.Handle, attachVirtualDiskFlag AttachVirtua
 		parameters,
 		nil,
 	); err != nil {
-		return errors.Wrap(err, "failed to attach virtual disk")
+		return fmt.Errorf("failed to attach virtual disk: %w", err)
 	}
 	return nil
 }
@@ -209,7 +208,7 @@ func AttachVhd(path string) (err error) {
 		AttachVirtualDiskFlagNone,
 		&params,
 	); err != nil {
-		return errors.Wrap(err, "failed to attach virtual disk")
+		return fmt.Errorf("failed to attach virtual disk: %w", err)
 	}
 	return nil
 }
@@ -246,7 +245,7 @@ func OpenVirtualDiskWithParameters(vhdPath string, virtualDiskAccessMask Virtual
 		parameters,
 		&handle,
 	); err != nil {
-		return 0, errors.Wrap(err, "failed to open virtual disk")
+		return 0, fmt.Errorf("failed to open virtual disk: %w", err)
 	}
 	return handle, nil
 }
@@ -272,7 +271,7 @@ func CreateVirtualDisk(path string, virtualDiskAccessMask VirtualDiskAccessMask,
 		nil,
 		&handle,
 	); err != nil {
-		return handle, errors.Wrap(err, "failed to create virtual disk")
+		return handle, fmt.Errorf("failed to create virtual disk: %w", err)
 	}
 	return handle, nil
 }
@@ -290,7 +289,7 @@ func GetVirtualDiskPhysicalPath(handle syscall.Handle) (_ string, err error) {
 		&diskPathSizeInBytes,
 		&diskPhysicalPathBuf[0],
 	); err != nil {
-		return "", errors.Wrap(err, "failed to get disk physical path")
+		return "", fmt.Errorf("failed to get disk physical path: %w", err)
 	}
 	return windows.UTF16ToString(diskPhysicalPathBuf[:]), nil
 }
@@ -314,10 +313,10 @@ func CreateDiffVhd(diffVhdPath, baseVhdPath string, blockSizeInMB uint32) error 
 		createParams,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create differencing vhd: %s", err)
+		return fmt.Errorf("failed to create differencing vhd: %w", err)
 	}
 	if err := syscall.CloseHandle(vhdHandle); err != nil {
-		return fmt.Errorf("failed to close differencing vhd handle: %s", err)
+		return fmt.Errorf("failed to close differencing vhd handle: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Since Go version 1.13, the standard library has built-in support for
wrapping and unwrapping of error values.  This commit bumps the minimum
version required by the module from 1.12 to 1.13, replaces all calls to
errors.Wrap/f with fmt.Errorf and removes the now unneeded dependency on
github.com/pkg/errors.

Signed-off-by: Michael Hofmann <michael.hofmann@bitgestalt.com>