### PR TITLE
Bump go version to 1.17 in go.mod/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.0'
+          go-version: '^1.17.0'
 
       - run: go build ./pkg/etw/sample/
       - run: go build ./tools/etw-provider-gen/

--- a/backup.go
+++ b/backup.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/backup_test.go
+++ b/backup_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/ea_test.go
+++ b/ea_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/file.go
+++ b/file.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/fileinfo.go
+++ b/fileinfo.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Microsoft/go-winio
 
-go 1.13
+go 1.17
 
 require (
 	github.com/sirupsen/logrus v1.7.0

--- a/hvsock.go
+++ b/hvsock.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/pipe.go
+++ b/pipe.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/privilege.go
+++ b/privilege.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/privileges_test.go
+++ b/privileges_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/sd.go
+++ b/sd.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio

--- a/sd_test.go
+++ b/sd_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio


### PR DESCRIPTION
1.13 is sufficiently old at this point and net.ErrClosed from 1.16 will be nice
to use.

This change additionally runs go fmt to bring in the new 1.17 build tag syntax
and builds the binaries in our CI with 1.17+.