### PR TITLE
HVsock Registry Application Registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.vscode/
+
 *.exe

--- a/hvsock.go
+++ b/hvsock.go
@@ -336,7 +336,7 @@ func HvsockRegisterService(id guid.GUID, name string) error {
 	return nil
 }
 
-// HvSockUnregisterService deleted the registration defined by the guid from the Hyper-V Host's registry.
+// HvsockUnregisterService deletes the registration defined by the guid from the Hyper-V Host's registry.
 func HvsockUnregisterService(id guid.GUID) error {
 	return registry.DeleteKey(registry.LOCAL_MACHINE, hvSocketRegKey(id))
 }


### PR DESCRIPTION
Using Hyper-V sockets requires [registering the application](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/make-integration-service#register-a-new-application) in the Windows Registry.

This PR adds (de)registration functionality for an application name/GUID.

This PR is split from #235 

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>