### PR TITLE
Updating windows build constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   test:
-    runs-on: 'windows-2019'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022, ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/fileinfo_test.go
+++ b/fileinfo_test.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package winio
 
 import (

--- a/pkg/guid/guid.go
+++ b/pkg/guid/guid.go
@@ -1,5 +1,3 @@
-// +build windows
-
 // Package guid provides a GUID type. The backing structure for a GUID is
 // identical to that used by the golang.org/x/sys/windows GUID type.
 // There are two main binary encodings used for a GUID, the big-endian encoding,

--- a/pkg/guid/guid_nonwindows.go
+++ b/pkg/guid/guid_nonwindows.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package guid

--- a/pkg/guid/guid_test.go
+++ b/pkg/guid/guid_test.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package guid
 
 import (

--- a/pkg/guid/guid_windows.go
+++ b/pkg/guid/guid_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package guid
 
 import "golang.org/x/sys/windows"

--- a/reparse.go
+++ b/reparse.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package winio
 
 import (


### PR DESCRIPTION
#191 added build guard to go-winio, but "pkg/guid" now works on both windows and linux, and is not OS dependent.
This PR is needed to allow using windows-style GUIDs on Linux code that interops with Windows.

Removed build guards from pkg/guid/guid.go.
Build constraints to guid_windows and guid_nonwindows, which redundant with file names, but added for consistency.

Added missing build constraints to other files.

Added Ubuntu to test matrix, along with windows 2022.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>