### PR TITLE
Assign ErrPipeListenerClosed to net.ErrClosed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.0'
       - run: go test -gcflags=all=-d=checkptr -v ./...
 
   build:

--- a/pipe.go
+++ b/pipe.go
@@ -89,8 +89,7 @@ const (
 
 var (
 	// ErrPipeListenerClosed is returned for pipe operations on listeners that have been closed.
-	// This error should match net.errClosing since docker takes a dependency on its text.
-	ErrPipeListenerClosed = errors.New("use of closed network connection")
+	ErrPipeListenerClosed = net.ErrClosed
 
 	errPipeWriteClosed = errors.New("pipe has been closed for write")
 )


### PR DESCRIPTION
This error used to just be a `errors.New` with the text exactly matching the "use of closed network connection" that you'd get from the Go stdlib. Now that that error was exported as `net.ErrClosed` in Go 1.16 we should
be able to swap to this safely.