### PR TITLE
tools/mkwinsyscall: remove errnoERROR_IO_PENDING const

### DIFF
--- a/internal/socket/zsyscall_windows.go
+++ b/internal/socket/zsyscall_windows.go
@@ -15,12 +15,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -30,7 +26,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/pkg/etw/zsyscall_windows.go
+++ b/pkg/etw/zsyscall_windows.go
@@ -15,12 +15,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -30,7 +26,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/pkg/process/zsyscall_windows.go
+++ b/pkg/process/zsyscall_windows.go
@@ -15,12 +15,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -30,7 +26,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/pkg/security/zsyscall_windows.go
+++ b/pkg/security/zsyscall_windows.go
@@ -15,12 +15,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -30,7 +26,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/tools/mkwinsyscall/mkwinsyscall.go
+++ b/tools/mkwinsyscall/mkwinsyscall.go
@@ -938,12 +938,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = {{syscalldot}}Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = {{windowsdot}}ERROR_IO_PENDING
 	errERROR_EINVAL error     = {{syscalldot}}EINVAL
 )
 
@@ -953,7 +949,7 @@ func errnoErr(e {{syscalldot}}Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case {{windowsdot}}ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/vhd/zvhd_windows.go
+++ b/vhd/zvhd_windows.go
@@ -15,12 +15,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -30,7 +26,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -15,12 +15,8 @@ var _ unsafe.Pointer
 
 // Do the interface allocations only once for common
 // Errno values.
-const (
-	errnoERROR_IO_PENDING = 997
-)
-
 var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_IO_PENDING error = windows.ERROR_IO_PENDING
 	errERROR_EINVAL     error = syscall.EINVAL
 )
 
@@ -30,7 +26,7 @@ func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
 		return errERROR_EINVAL
-	case errnoERROR_IO_PENDING:
+	case windows.ERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
 	// TODO: add more here, after collecting data on the common


### PR DESCRIPTION
- related https://github.com/golang/sys/pull/140

From the looks of it, this const is redundant (but perhaps there's something I'm overlooking 😅)