### PR TITLE
Add WriteEventString function.

### DIFF
--- a/pkg/etw/provider.go
+++ b/pkg/etw/provider.go
@@ -220,6 +220,21 @@ func (provider *Provider) IsEnabledForLevelAndKeywords(level Level, keywords uin
 	return true
 }
 
+// WriteEventString writes a single ETW event from the provider that contains the string
+// as its data with the field name set to "Message".
+//
+// It is a wrapper around [Provider.WriteEvent], and meant to replace directly calling the
+// [ETW WriteEventString] syscall, which should not be used.
+//
+// Deprecated: Use [Provider.WriteEvent] instead.
+//
+// [ETW WriteEventString]: https://learn.microsoft.com/en-us/windows/win32/api/evntprov/nf-evntprov-eventwritestring#remarks
+func (provider *Provider) WriteEventString(message string) error {
+	opts := []EventOpt{WithLevel(0)}
+	fields := []FieldOpt{StringField("Message", message)}
+	return provider.WriteEvent("", opts, fields)
+}
+
 // WriteEvent writes a single ETW event from the provider. The event is
 // constructed based on the EventOpt and FieldOpt values that are passed as
 // opts.

--- a/pkg/etw/sample/main_windows.go
+++ b/pkg/etw/sample/main_windows.go
@@ -84,6 +84,11 @@ func main() {
 		return
 	}
 
+	if err := provider.WriteEventString("TestEventString"); err != nil {
+		logrus.Error(err)
+		return
+	}
+
 	if err := providerWithGroup.WriteEvent(
 		"TestEventWithGroup",
 		etw.WithEventOpts(
@@ -104,6 +109,11 @@ func main() {
 				"Item5",
 			})),
 	); err != nil {
+		logrus.Error(err)
+		return
+	}
+
+	if err := providerWithGroup.WriteEventString("TestEventStringWithGroup"); err != nil {
 		logrus.Error(err)
 		return
 	}


### PR DESCRIPTION
This is an implementation of #262.

Adds a `(*Provider).WriteEventString` to write a single string to ETW
Since the intent is to add an intermediary function for Moby to call while they transition to this library, the function is marked as deprecated, to ward against future use.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>