### PR TITLE
Soften linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
   test:
     name: Run Tests
     needs:
-      - lint
       - go-generate
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,8 @@ linters:
     - containedctx # struct contains a context
     - dupl # duplicate code
     - errname # erorrs are named correctly
-    - goconst # strings that should be constants
-    - godot # comments end in a period
-    - misspell
     - nolintlint # "//nolint" directives are properly explained
     - revive # golint replacement
-    - stylecheck # golint replacement, less configurable than revive
     - unconvert # unnecessary conversions
     - wastedassign
 
@@ -23,9 +19,7 @@ linters:
     - exhaustive # check exhaustiveness of enum switch statements
     - gofmt # files are gofmt'ed
     - gosec # security
-    - nestif # deeply nested ifs
     - nilerr # returns nil even with non-nil error
-    - prealloc # slices that can be pre-allocated
     - structcheck # unused struct fields
     - unparam # unused function params
 
@@ -56,6 +50,8 @@ issues:
 
 
 linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
   govet:
     enable-all: true
     disable:
@@ -138,7 +134,3 @@ linters-settings:
             - VPCI
             - WCOW
             - WIM
-  stylecheck:
-    checks:
-      - "all"
-      - "-ST1003" # use revive's var naming


### PR DESCRIPTION
Remove some aggressive linters: `godoc`, `goconst`, `misspel`, `nestif`, and `prealloc.
Also remove `stylecheck` since it is subsumed by `revive`, and the later is more configurable.

Allow tests and build stages to continue even if linter fails.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>