### PR TITLE
Bump linter, remove structcheck, ignore unhandled_errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.50
           args: >-
             --verbose
             --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - gofmt # files are gofmt'ed
     - gosec # security
     - nilerr # returns nil even with non-nil error
-    - structcheck # unused struct fields
     - unparam # unused function params
 
 issues:
@@ -93,6 +92,8 @@ linters-settings:
       - name: confusing-naming # we frequently use "Foo()" and "foo()" together
         disabled: true
       - name: flag-parameter # excessive, and a common idiom we use
+        disabled: true
+      - name: unhandled-error # warns over common fmt.Print* and io.Close; rely on errcheck instead
         disabled: true
       # general config
       - name: line-length-limit


### PR DESCRIPTION
Update golanci-lint to 1.50, and remove `structcheck`, which was deprecated in new version.
Additionally, disable `revive`s `unhandled_errors` linter, since currently `errcheck` (a default linter) does the same, and ignores common situations (eg, `io.Close`, `fmt.Print`).

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>