### PR TITLE
pkg/etw/sample: remove dependency on github.com/sirupsen/logrus

### DIFF
--- a/pkg/etw/sample/main_windows.go
+++ b/pkg/etw/sample/main_windows.go
@@ -7,12 +7,12 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"runtime"
 
 	"github.com/Microsoft/go-winio/pkg/etw"
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"github.com/sirupsen/logrus"
 )
 
 func callback(sourceID guid.GUID, state etw.ProviderState, level etw.Level, matchAnyKeyword uint64, matchAllKeyword uint64, filterData uintptr) {
@@ -24,31 +24,28 @@ func main() {
 
 	group, err := guid.FromString("12341234-abcd-abcd-abcd-123412341234")
 	if err != nil {
-		logrus.Error(err)
-		return
+		log.Fatal(err)
 	}
 
 	provider, err := etw.NewProvider("TestProvider", callback)
 
 	if err != nil {
-		logrus.Error(err)
-		return
+		log.Fatal(err)
 	}
 	defer func() {
 		if err := provider.Close(); err != nil {
-			logrus.Error(err)
+			log.Fatal(err)
 		}
 	}()
 
 	providerWithGroup, err := etw.NewProviderWithOptions("TestProviderWithGroup", etw.WithGroup(group), etw.WithCallback(callback))
 
 	if err != nil {
-		logrus.Error(err)
-		return
+		log.Fatal(err)
 	}
 	defer func() {
 		if err := providerWithGroup.Close(); err != nil {
-			logrus.Error(err)
+			log.Fatal(err)
 		}
 	}()
 
@@ -80,8 +77,7 @@ func main() {
 				"Item5",
 			})),
 	); err != nil {
-		logrus.Error(err)
-		return
+		log.Fatal(err)
 	}
 
 	if err := providerWithGroup.WriteEvent(
@@ -104,7 +100,6 @@ func main() {
 				"Item5",
 			})),
 	); err != nil {
-		logrus.Error(err)
-		return
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
It looks like for the purpose of the example "a" logger was needed, so not strictly logrus (probably `fmt.Println()` would've worked even).

This patch removes logrus as dependency for the example. The only remaining use of logrus in this repository is now in the pkg/etc/etwlogrus package, which _does_ need logrus, but (possibly) could become its own module if we want to remove logrus as dependency of go-winio itself.
