### PR TITLE
Apply two upstream CL to mkwinsyscall

### DIFF
--- a/tools/mkwinsyscall/mkwinsyscall.go
+++ b/tools/mkwinsyscall/mkwinsyscall.go
@@ -477,15 +477,14 @@ func newFn(s string) (*Fn, error) {
 		return nil, errors.New("Could not extract dll name from \"" + f.src + "\"")
 	}
 	s = trim(s[1:])
-	a := strings.Split(s, ".")
-	switch len(a) {
-	case 1:
-		f.dllfuncname = a[0]
-	case 2:
-		f.dllname = a[0]
-		f.dllfuncname = a[1]
-	default:
-		return nil, errors.New("Could not extract dll name from \"" + f.src + "\"")
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		f.dllname = s[:i]
+		f.dllfuncname = s[i+1:]
+	} else {
+		f.dllfuncname = s
+	}
+	if f.dllfuncname == "" {
+		return nil, fmt.Errorf("function name is not specified in %q", s)
 	}
 	if n := f.dllfuncname; endsIn(n, '?') {
 		f.dllfuncname = n[:len(n)-1]
@@ -502,7 +501,23 @@ func (f *Fn) DLLName() string {
 	return f.dllname
 }
 
-// DLLName returns DLL function name for function f.
+// DLLVar returns a valid Go identifier that represents DLLName.
+func (f *Fn) DLLVar() string {
+	id := strings.Map(func(r rune) rune {
+		switch r {
+		case '.', '-':
+			return '_'
+		default:
+			return r
+		}
+	}, f.DLLName())
+	if !token.IsIdentifier(id) {
+		panic(fmt.Errorf("could not create Go identifier for DLLName %q", f.DLLName()))
+	}
+	return id
+}
+
+// DLLFuncName returns DLL function name for function f.
 func (f *Fn) DLLFuncName() string {
 	if f.dllfuncname == "" {
 		return f.Name
@@ -648,6 +663,13 @@ func (f *Fn) HelperName() string {
 	return "_" + f.Name
 }
 
+// DLL is a DLL's filename and a string that is valid in a Go identifier that should be used when
+// naming a variable that refers to the DLL.
+type DLL struct {
+	Name string
+	Var  string
+}
+
 // Source files and functions.
 type Source struct {
 	Funcs           []*Fn
@@ -697,18 +719,20 @@ func ParseFiles(fs []string) (*Source, error) {
 }
 
 // DLLs return dll names for a source set src.
-func (src *Source) DLLs() []string {
+func (src *Source) DLLs() []DLL {
 	uniq := make(map[string]bool)
-	r := make([]string, 0)
+	r := make([]DLL, 0)
 	for _, f := range src.Funcs {
-		name := f.DLLName()
-		if _, found := uniq[name]; !found {
-			uniq[name] = true
-			r = append(r, name)
+		id := f.DLLVar()
+		if _, found := uniq[id]; !found {
+			uniq[id] = true
+			r = append(r, DLL{f.DLLName(), id})
 		}
 	}
 	if *sortdecls {
-		sort.Strings(r)
+		sort.Slice(r, func(i, j int) bool {
+			return r[i].Var < r[j].Var
+		})
 	}
 	return r
 }
@@ -991,10 +1015,10 @@ var (
 
 {{/* help functions */}}
 
-{{define "dlls"}}{{range .DLLs}}	mod{{.}} = {{newlazydll .}}
+{{define "dlls"}}{{range .DLLs}}	mod{{.Var}} = {{newlazydll .Name}}
 {{end}}{{end}}
 
-{{define "funcnames"}}{{range .DLLFuncNames}}	proc{{.DLLFuncName}} = mod{{.DLLName}}.NewProc("{{.DLLFuncName}}")
+{{define "funcnames"}}{{range .DLLFuncNames}}	proc{{.DLLFuncName}} = mod{{.DLLVar}}.NewProc("{{.DLLFuncName}}")
 {{end}}{{end}}
 
 {{define "helperbody"}}


### PR DESCRIPTION
Add two change lists that were added to `golang.org/x/sys/windows/mkwinsyscall`:
1. [support "." and "-" in DLL name](https://go-review.googlesource.com/c/sys/+/463215)
2. [write source to temp file if formatting fails](https://go-review.googlesource.com/c/sys/+/463216)