### PR TITLE
update linter and fix lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,26 @@ on:
   - pull_request
 
 env:
-  GO_VERSION: "1.17"
+  GO_VERSION: "oldstable"
+  GOTESTSUM_VERSION: "latest"
 
 jobs:
   lint:
     name: Lint
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install go
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50
+          version: v1.52
           args: >-
             --verbose
             --timeout=5m
@@ -31,10 +36,14 @@ jobs:
     name: Go Generate
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install go
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+
       - name: Run go generate
         shell: pwsh
         run: |
@@ -45,6 +54,7 @@ jobs:
             Write-Output "::error title=Go Generate::Error running go generate."
             exit $LASTEXITCODE
           }
+
       - name: Diff
         shell: pwsh
         run: |
@@ -66,11 +76,19 @@ jobs:
       matrix:
         os: [windows-2019, windows-2022, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install go
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - run: go test -gcflags=all=-d=checkptr -v ./...
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@${{ env.GOTESTSUM_VERSION }}
+
+      - name: Test repo
+        run: gotestsum --format standard-verbose --debug -- -gcflags=all=-d=checkptr -v ./...
 
   build:
     name: Build Repo
@@ -78,10 +96,14 @@ jobs:
       - test
     runs-on: "windows-2019"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install go
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+
       - run: go build ./pkg/etw/sample/
       - run: go build ./tools/etw-provider-gen/
       - run: go build ./tools/mkwinsyscall/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,18 @@ issues:
       text: "^line-length-limit: "
       source: "^//(go:generate|sys) "
 
+    #TODO: remove after upgrading to go1.18
+    # ignore comment spacing for nolint and sys directives
+    - linters:
+        - revive
+      text: "^comment-spacings: no space between comment delimiter and comment text"
+      source: "//(cspell:|nolint:|sys |todo)"
+
+    # not on go 1.18 yet, so no any
+    - linters:
+        - revive
+      text: "^use-any: since GO 1.18 'interface{}' can be replaced by 'any'"
+
     # allow unjustified ignores of error checks in defer statements
     - linters:
         - nolintlint

--- a/hvsock.go
+++ b/hvsock.go
@@ -23,7 +23,7 @@ import (
 const afHVSock = 34 // AF_HYPERV
 
 // Well known Service and VM IDs
-//https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/make-integration-service#vmid-wildcards
+// https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/make-integration-service#vmid-wildcards
 
 // HvsockGUIDWildcard is the wildcard VmId for accepting connections from all partitions.
 func HvsockGUIDWildcard() guid.GUID { // 00000000-0000-0000-0000-000000000000
@@ -31,7 +31,7 @@ func HvsockGUIDWildcard() guid.GUID { // 00000000-0000-0000-0000-000000000000
 }
 
 // HvsockGUIDBroadcast is the wildcard VmId for broadcasting sends to all partitions.
-func HvsockGUIDBroadcast() guid.GUID { //ffffffff-ffff-ffff-ffff-ffffffffffff
+func HvsockGUIDBroadcast() guid.GUID { // ffffffff-ffff-ffff-ffff-ffffffffffff
 	return guid.GUID{
 		Data1: 0xffffffff,
 		Data2: 0xffff,
@@ -246,7 +246,7 @@ func (l *HvsockListener) Accept() (_ net.Conn, err error) {
 	var addrbuf [addrlen * 2]byte
 
 	var bytes uint32
-	err = syscall.AcceptEx(l.sock.handle, sock.handle, &addrbuf[0], 0 /*rxdatalen*/, addrlen, addrlen, &bytes, &c.o)
+	err = syscall.AcceptEx(l.sock.handle, sock.handle, &addrbuf[0], 0 /* rxdatalen */, addrlen, addrlen, &bytes, &c.o)
 	if _, err = l.sock.asyncIO(c, nil, bytes, err); err != nil {
 		return nil, l.opErr("accept", os.NewSyscallError("acceptex", err))
 	}

--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -100,8 +100,8 @@ func (f *runtimeFunc) Load() error {
 			(*byte)(unsafe.Pointer(&f.addr)),
 			uint32(unsafe.Sizeof(f.addr)),
 			&n,
-			nil, //overlapped
-			0,   //completionRoutine
+			nil, // overlapped
+			0,   // completionRoutine
 		)
 	})
 	return f.err

--- a/internal/stringbuffer/wstring.go
+++ b/internal/stringbuffer/wstring.go
@@ -15,7 +15,7 @@ const MinWStringCap = 310
 // use *[]uint16 since []uint16 creates an extra allocation where the slice header
 // is copied to heap and then referenced via pointer in the interface header that sync.Pool
 // stores.
-var pathPool = sync.Pool{ //! if go1.18+ adds Pool[T], use that to store []uint16 directly
+var pathPool = sync.Pool{ // if go1.18+ adds Pool[T], use that to store []uint16 directly
 	New: func() interface{} {
 		b := make([]uint16, MinWStringCap)
 		return &b
@@ -108,7 +108,7 @@ func (b *WString) String() string {
 	// Using [windows.UTF16ToString] would require importing "golang.org/x/sys/windows"
 	// and would make this code Windows-only, which makes no sense.
 	// So copy UTF16ToString code into here.
-	//! If other windows-specific code is added, switch to [windows.UTF16ToString]
+	// If other windows-specific code is added, switch to [windows.UTF16ToString]
 
 	s := b.b
 	for i, v := range s {

--- a/pipe.go
+++ b/pipe.go
@@ -176,7 +176,7 @@ func tryDialPipe(ctx context.Context, path *string, access fs.AccessMask) (sysca
 				nil, // security attributes
 				fs.OPEN_EXISTING,
 				fs.FILE_FLAG_OVERLAPPED|fs.SECURITY_SQOS_PRESENT|fs.SECURITY_ANONYMOUS,
-				0, //template file handle
+				0, // template file handle
 			)
 			h := syscall.Handle(wh)
 			if err == nil {

--- a/pkg/etw/eventdescriptor.go
+++ b/pkg/etw/eventdescriptor.go
@@ -47,8 +47,6 @@ const (
 )
 
 // EventDescriptor represents various metadata for an ETW event.
-//
-//nolint:structcheck // task is currently unused
 type eventDescriptor struct {
 	id      uint16
 	version uint8

--- a/pkg/security/grantvmgroupaccess.go
+++ b/pkg/security/grantvmgroupaccess.go
@@ -21,7 +21,6 @@ type (
 	trusteeForm         uint32
 	trusteeType         uint32
 
-	//nolint:structcheck // structcheck thinks fields are unused, but the are used to pass data to OS
 	explicitAccess struct {
 		accessPermissions accessMask
 		accessMode        accessMode
@@ -29,7 +28,6 @@ type (
 		trustee           trustee
 	}
 
-	//nolint:structcheck,unused // structcheck thinks fields are unused, but the are used to pass data to OS
 	trustee struct {
 		multipleTrustee          *trustee
 		multipleTrusteeOperation int32

--- a/wim/lzx/lzx.go
+++ b/wim/lzx/lzx.go
@@ -489,14 +489,13 @@ func (f *decompressor) readCompressedBlock(start, end uint16, hmain, hlength, ha
 			f.lru[0] = matchoffset
 		}
 
-		if matchoffset <= i && matchlen <= end-i {
-			copyend := i + matchlen
-			for ; i < copyend; i++ {
-				f.window[i] = f.window[i-matchoffset]
-			}
-		} else {
+		if !(matchoffset <= i && matchlen <= end-i) {
 			f.fail(errCorrupt)
 			break
+		}
+		copyend := i + matchlen
+		for ; i < copyend; i++ {
+			f.window[i] = f.window[i-matchoffset]
 		}
 	}
 	return int(i - start), f.err


### PR DESCRIPTION
Update linter to 1.52, update go used in CI to 1.19
Fix various lint errors, mostly comment spacing

Use gotestsum in CI to pretty up testing logs
Add names to CI steps for prettier UI experience