### PR TITLE
Allow ETW to use thread's activity ID

### DIFF
--- a/pkg/etw/activityid.go
+++ b/pkg/etw/activityid.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package etw
+
+import "github.com/Microsoft/go-winio/pkg/guid"
+
+type eventActivityIDControlCode uint32
+
+//nolint:unused // all values listed here for completeness.
+const (
+	// Sets the ActivityId parameter to the value of the current thread's activity ID.
+	getEventActivityID eventActivityIDControlCode = iota + 1
+	// Sets the current thread's activity ID to the value of the ActivityId parameter.
+	setEventActivityID
+	// Sets the ActivityId parameter to the value of a newly-generated locally-unique activity ID.
+	createEventActivityID
+	// Swaps the values of the ActivityId parameter and the current thread's activity ID.
+	// (Saves the value of the current thread's activity ID, then sets the current thread's activity ID to
+	// the value of the ActivityId parameter, then sets the ActivityId parameter to the saved value.)
+	getSetEventActivityID
+	// Sets the ActivityId parameter to the value of the current thread's activity ID,
+	// then sets the current thread's activity ID to the value of a newly-generated locally-unique activity ID
+	createSetEventActivityID
+)
+
+// Activity ID is thread local, but since go doesn't expose a way to initialize threads,
+// we have no way of calling this for all threads, or even knowing if the current thread
+// was initialized without a syscall to [eventActivityIdControl]
+
+// InitializeThreadActivityID checks if the current thread's activity ID is empty, and, if so,
+// creates a new activity ID for the thread.
+//
+// Subsequent ETW calls from this thread will use that Activity ID, if no ID is specified.
+//
+// See [EventActivityIdControl] for more information.
+//
+// [EventActivityIdControl]: https://learn.microsoft.com/en-us/windows/win32/api/evntprov/nf-evntprov-eventactivityidcontrol
+func InitializeThreadActivityID() (guid.GUID, error) {
+	// check if the current thread is intialized
+	var g guid.GUID
+	if err := eventActivityIdControl(getEventActivityID, &g); err != nil {
+		return guid.GUID{}, err
+	}
+	if !g.IsEmpty() {
+		return g, nil
+	}
+
+	// create a new activity ID
+	if err := eventActivityIdControl(createEventActivityID, &g); err != nil {
+		return guid.GUID{}, err
+	}
+
+	// set the ID
+	if err := eventActivityIdControl(setEventActivityID, &g); err != nil {
+		return guid.GUID{}, err
+	}
+	return g, nil
+}
+
+// GetThreadActivityID returns the current thread's activity ID.
+//
+// See [InitializeThreadActivityID] for more details.
+func GetThreadActivityID() (guid.GUID, error) {
+	var g guid.GUID
+	err := eventActivityIdControl(getEventActivityID, &g)
+	return g, err
+}
+
+// SetThreadActivityID returns the current thread's activity ID.
+//
+// See [InitializeThreadActivityID] for more details.
+func SetThreadActivityID(g guid.GUID) error {
+	return eventActivityIdControl(setEventActivityID, &g)
+}

--- a/pkg/etw/newprovider.go
+++ b/pkg/etw/newprovider.go
@@ -40,7 +40,7 @@ func NewProviderWithOptions(name string, options ...ProviderOpt) (provider *Prov
 	provider.ID = opts.id
 	provider.callback = opts.callback
 
-	if err := eventRegister((*windows.GUID)(&provider.ID), globalProviderCallback, uintptr(provider.index), &provider.handle); err != nil {
+	if err := eventRegister(&provider.ID, globalProviderCallback, uintptr(provider.index), &provider.handle); err != nil {
 		return nil, err
 	}
 

--- a/pkg/etw/syscall.go
+++ b/pkg/etw/syscall.go
@@ -2,14 +2,23 @@
 
 package etw
 
-//go:generate go run github.com/Microsoft/go-winio/tools/mkwinsyscall -output zsyscall_windows.go syscall.go
+//go:generate go run github.com/Microsoft/go-winio/tools/mkwinsyscall -imports "github.com/Microsoft/go-winio/pkg/guid" -output zsyscall_windows.go syscall.go
 
-//sys eventRegister(providerId *windows.GUID, callback uintptr, callbackContext uintptr, providerHandle *providerHandle) (win32err error) = advapi32.EventRegister
+//sys eventRegister(providerId *guid.GUID, callback uintptr, callbackContext uintptr, providerHandle *providerHandle) (win32err error) = advapi32.EventRegister
 
 //sys eventUnregister_64(providerHandle providerHandle) (win32err error) = advapi32.EventUnregister
-//sys eventWriteTransfer_64(providerHandle providerHandle, descriptor *eventDescriptor, activityID *windows.GUID, relatedActivityID *windows.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
+//sys eventWriteTransfer_64(providerHandle providerHandle, descriptor *eventDescriptor, activityID *guid.GUID, relatedActivityID *guid.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
 //sys eventSetInformation_64(providerHandle providerHandle, class eventInfoClass, information uintptr, length uint32) (win32err error) = advapi32.EventSetInformation
 
 //sys eventUnregister_32(providerHandle_low uint32, providerHandle_high uint32) (win32err error) = advapi32.EventUnregister
-//sys eventWriteTransfer_32(providerHandle_low uint32, providerHandle_high uint32, descriptor *eventDescriptor, activityID *windows.GUID, relatedActivityID *windows.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
+//sys eventWriteTransfer_32(providerHandle_low uint32, providerHandle_high uint32, descriptor *eventDescriptor, activityID *guid.GUID, relatedActivityID *guid.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
 //sys eventSetInformation_32(providerHandle_low uint32, providerHandle_high uint32, class eventInfoClass, information uintptr, length uint32) (win32err error) = advapi32.EventSetInformation
+
+//  ULONG EVNTAPI EventActivityIdControl(
+//    [in]      ULONG  ControlCode,
+//    [in, out] LPGUID ActivityId
+//  );
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/evntprov/nf-evntprov-eventactivityidcontrol
+//
+//sys eventActivityIdControl(code eventActivityIDControlCode, activityID *guid.GUID) (win32err error)= advapi32.EventActivityIdControl?

--- a/pkg/etw/wrapper_32.go
+++ b/pkg/etw/wrapper_32.go
@@ -24,8 +24,8 @@ func eventUnregister(providerHandle providerHandle) (win32err error) {
 func eventWriteTransfer(
 	providerHandle providerHandle,
 	descriptor *eventDescriptor,
-	activityID *windows.GUID,
-	relatedActivityID *windows.GUID,
+	activityID *guid.GUID,
+	relatedActivityID *guid.GUID,
 	dataDescriptorCount uint32,
 	dataDescriptors *eventDataDescriptor) (win32err error) {
 

--- a/pkg/etw/wrapper_64.go
+++ b/pkg/etw/wrapper_64.go
@@ -6,7 +6,6 @@ package etw
 
 import (
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"golang.org/x/sys/windows"
 )
 
 func eventUnregister(providerHandle providerHandle) (win32err error) {
@@ -16,8 +15,8 @@ func eventUnregister(providerHandle providerHandle) (win32err error) {
 func eventWriteTransfer(
 	providerHandle providerHandle,
 	descriptor *eventDescriptor,
-	activityID *windows.GUID,
-	relatedActivityID *windows.GUID,
+	activityID *guid.GUID,
+	relatedActivityID *guid.GUID,
 	dataDescriptorCount uint32,
 	dataDescriptors *eventDataDescriptor) (win32err error) {
 	return eventWriteTransfer_64(

--- a/pkg/guid/guid.go
+++ b/pkg/guid/guid.go
@@ -220,7 +220,7 @@ func (g GUID) MarshalText() ([]byte, error) {
 	return []byte(g.String()), nil
 }
 
-// UnmarshalText takes the textual representation of a GUID, and unmarhals it
+// UnmarshalText takes the textual representation of a GUID, and unmarshals it
 // into this GUID.
 func (g *GUID) UnmarshalText(text []byte) error {
 	g2, err := FromString(string(text))
@@ -230,3 +230,9 @@ func (g *GUID) UnmarshalText(text []byte) error {
 	*g = g2
 	return nil
 }
+
+// hopefully this saves on allocating a new GUID per g.Empty() call
+var empty GUID
+
+// IsEmpty returns if the GUID is equal to 00000000-0000-0000-0000-000000000000
+func (g *GUID) IsEmpty() bool { return *g == empty }

--- a/tools/mkwinsyscall/mkwinsyscall.go
+++ b/tools/mkwinsyscall/mkwinsyscall.go
@@ -53,6 +53,7 @@ var (
 	winio          = flag.Bool("winio", false, `import this package ("github.com/Microsoft/go-winio")`)
 	utf16          = flag.Bool("utf16", true, "encode string arguments as UTF-16 for syscalls not ending in 'A' or 'W'")
 	sortdecls      = flag.Bool("sort", true, "sort DLL and function declarations")
+	extraImports   = flag.String("imports", "", "comma separated list of additional `packages` to import")
 )
 
 func trim(s string) string {
@@ -873,6 +874,12 @@ func (src *Source) Generate(w io.Writer) error {
 	if packageName != "syscall" {
 		src.Import("syscall")
 	}
+	if *extraImports != "" {
+		for _, pkg := range strings.Split(*extraImports, ",") {
+			src.ExternalImport(pkg)
+		}
+	}
+
 	funcMap := template.FuncMap{
 		"packagename": packagename,
 		"syscalldot":  syscalldot,


### PR DESCRIPTION
This commit is contains several related changes that ultimately allow ETW events to set their activity ID to the current thread's value. By setting the thread's activity ID, win32 API calls from that thread will be able to access it and either continue using it or set it as the related activity ID, improving tracing on Windows.

Update mkwisyscall to import arbitrary other packages, so generated functions can types defined elsewhere.

Switch ETW functions to use `guid.GUID` instead of `windows.GUID`.

Add convenience `IsEmpty` function for GUIDs.

Add `EventActivityIdControl` function to manipulate the thread's activity ID, and related `*ThreadActivityID` functions to set the thread activity ID to a non-empty value.

Update `writeEventRaw` to only pass (related) activity ID to `eventWriteTransfer` if they are non-empty.

This is not a breaking change, since related activity ID will remain the same, and the activity ID will only be changed when not specified if `InitializeThreadActivityID` or `SetThreadActivityID` are called before-hand.