### PR TITLE
Switch from sycall to windows

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -10,14 +10,14 @@ import (
 	"io"
 	"os"
 	"runtime"
-	"syscall"
 	"unicode/utf16"
 
+	"github.com/Microsoft/go-winio/internal/fs"
 	"golang.org/x/sys/windows"
 )
 
-//sys backupRead(h syscall.Handle, b []byte, bytesRead *uint32, abort bool, processSecurity bool, context *uintptr) (err error) = BackupRead
-//sys backupWrite(h syscall.Handle, b []byte, bytesWritten *uint32, abort bool, processSecurity bool, context *uintptr) (err error) = BackupWrite
+//sys backupRead(h windows.Handle, b []byte, bytesRead *uint32, abort bool, processSecurity bool, context *uintptr) (err error) = BackupRead
+//sys backupWrite(h windows.Handle, b []byte, bytesWritten *uint32, abort bool, processSecurity bool, context *uintptr) (err error) = BackupWrite
 
 const (
 	BackupData = uint32(iota + 1)
@@ -104,7 +104,7 @@ func (r *BackupStreamReader) Next() (*BackupHeader, error) {
 		if err := binary.Read(r.r, binary.LittleEndian, name); err != nil {
 			return nil, err
 		}
-		hdr.Name = syscall.UTF16ToString(name)
+		hdr.Name = windows.UTF16ToString(name)
 	}
 	if wsi.StreamID == BackupSparseBlock {
 		if err := binary.Read(r.r, binary.LittleEndian, &hdr.Offset); err != nil {
@@ -205,7 +205,7 @@ func NewBackupFileReader(f *os.File, includeSecurity bool) *BackupFileReader {
 // Read reads a backup stream from the file by calling the Win32 API BackupRead().
 func (r *BackupFileReader) Read(b []byte) (int, error) {
 	var bytesRead uint32
-	err := backupRead(syscall.Handle(r.f.Fd()), b, &bytesRead, false, r.includeSecurity, &r.ctx)
+	err := backupRead(windows.Handle(r.f.Fd()), b, &bytesRead, false, r.includeSecurity, &r.ctx)
 	if err != nil {
 		return 0, &os.PathError{Op: "BackupRead", Path: r.f.Name(), Err: err}
 	}
@@ -220,7 +220,7 @@ func (r *BackupFileReader) Read(b []byte) (int, error) {
 // the underlying file.
 func (r *BackupFileReader) Close() error {
 	if r.ctx != 0 {
-		_ = backupRead(syscall.Handle(r.f.Fd()), nil, nil, true, false, &r.ctx)
+		_ = backupRead(windows.Handle(r.f.Fd()), nil, nil, true, false, &r.ctx)
 		runtime.KeepAlive(r.f)
 		r.ctx = 0
 	}
@@ -244,7 +244,7 @@ func NewBackupFileWriter(f *os.File, includeSecurity bool) *BackupFileWriter {
 // Write restores a portion of the file using the provided backup stream.
 func (w *BackupFileWriter) Write(b []byte) (int, error) {
 	var bytesWritten uint32
-	err := backupWrite(syscall.Handle(w.f.Fd()), b, &bytesWritten, false, w.includeSecurity, &w.ctx)
+	err := backupWrite(windows.Handle(w.f.Fd()), b, &bytesWritten, false, w.includeSecurity, &w.ctx)
 	if err != nil {
 		return 0, &os.PathError{Op: "BackupWrite", Path: w.f.Name(), Err: err}
 	}
@@ -259,7 +259,7 @@ func (w *BackupFileWriter) Write(b []byte) (int, error) {
 // close the underlying file.
 func (w *BackupFileWriter) Close() error {
 	if w.ctx != 0 {
-		_ = backupWrite(syscall.Handle(w.f.Fd()), nil, nil, true, false, &w.ctx)
+		_ = backupWrite(windows.Handle(w.f.Fd()), nil, nil, true, false, &w.ctx)
 		runtime.KeepAlive(w.f)
 		w.ctx = 0
 	}
@@ -271,17 +271,14 @@ func (w *BackupFileWriter) Close() error {
 //
 // If the file opened was a directory, it cannot be used with Readdir().
 func OpenForBackup(path string, access uint32, share uint32, createmode uint32) (*os.File, error) {
-	winPath, err := syscall.UTF16FromString(path)
-	if err != nil {
-		return nil, err
-	}
-	h, err := syscall.CreateFile(&winPath[0],
-		access,
-		share,
+	h, err := fs.CreateFile(path,
+		fs.AccessMask(access),
+		fs.FileShareMode(share),
 		nil,
-		createmode,
-		syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_FLAG_OPEN_REPARSE_POINT,
-		0)
+		fs.FileCreationDisposition(createmode),
+		fs.FILE_FLAG_BACKUP_SEMANTICS|fs.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
 	if err != nil {
 		err = &os.PathError{Op: "open", Path: path, Err: err}
 		return nil, err

--- a/backup_test.go
+++ b/backup_test.go
@@ -6,7 +6,6 @@ package winio
 import (
 	"io"
 	"os"
-	"syscall"
 	"testing"
 
 	"golang.org/x/sys/windows"
@@ -202,7 +201,7 @@ func makeSparseFile() error {
 	}
 	defer f.Close()
 
-	err = syscall.DeviceIoControl(syscall.Handle(f.Fd()), windows.FSCTL_SET_SPARSE, nil, 0, nil, 0, nil, nil)
+	err = windows.DeviceIoControl(windows.Handle(f.Fd()), windows.FSCTL_SET_SPARSE, nil, 0, nil, 0, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/backuptar/tar.go
+++ b/backuptar/tar.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -106,7 +105,7 @@ func BasicInfoHeader(name string, size int64, fileInfo *winio.FileBasicInfo) *ta
 	hdr.PAXRecords[hdrFileAttributes] = fmt.Sprintf("%d", fileInfo.FileAttributes)
 	hdr.PAXRecords[hdrCreationTime] = formatPAXTime(time.Unix(0, fileInfo.CreationTime.Nanoseconds()))
 
-	if (fileInfo.FileAttributes & syscall.FILE_ATTRIBUTE_DIRECTORY) != 0 {
+	if (fileInfo.FileAttributes & windows.FILE_ATTRIBUTE_DIRECTORY) != 0 {
 		hdr.Mode |= cISDIR
 		hdr.Size = 0
 		hdr.Typeflag = tar.TypeDir
@@ -396,7 +395,7 @@ func FileInfoFromHeader(hdr *tar.Header) (name string, size int64, fileInfo *win
 		fileInfo.FileAttributes = uint32(attr)
 	} else {
 		if hdr.Typeflag == tar.TypeDir {
-			fileInfo.FileAttributes |= syscall.FILE_ATTRIBUTE_DIRECTORY
+			fileInfo.FileAttributes |= windows.FILE_ATTRIBUTE_DIRECTORY
 		}
 	}
 	if creationTimeStr, ok := hdr.PAXRecords[hdrCreationTime]; ok {

--- a/ea_test.go
+++ b/ea_test.go
@@ -6,9 +6,10 @@ package winio
 import (
 	"os"
 	"reflect"
-	"syscall"
 	"testing"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -82,7 +83,7 @@ func Test_SetFileEa(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 	defer f.Close()
-	ntdll := syscall.MustLoadDLL("ntdll.dll")
+	ntdll := windows.MustLoadDLL("ntdll.dll")
 	ntSetEaFile := ntdll.MustFindProc("NtSetEaFile")
 	var iosb [2]uintptr
 	r, _, _ := ntSetEaFile.Call(f.Fd(),

--- a/file.go
+++ b/file.go
@@ -15,11 +15,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-//sys cancelIoEx(file syscall.Handle, o *syscall.Overlapped) (err error) = CancelIoEx
-//sys createIoCompletionPort(file syscall.Handle, port syscall.Handle, key uintptr, threadCount uint32) (newport syscall.Handle, err error) = CreateIoCompletionPort
-//sys getQueuedCompletionStatus(port syscall.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) = GetQueuedCompletionStatus
-//sys setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err error) = SetFileCompletionNotificationModes
-//sys wsaGetOverlappedResult(h syscall.Handle, o *syscall.Overlapped, bytes *uint32, wait bool, flags *uint32) (err error) = ws2_32.WSAGetOverlappedResult
+//sys cancelIoEx(file windows.Handle, o *windows.Overlapped) (err error) = CancelIoEx
+//sys createIoCompletionPort(file windows.Handle, port windows.Handle, key uintptr, threadCount uint32) (newport windows.Handle, err error) = CreateIoCompletionPort
+//sys getQueuedCompletionStatus(port windows.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) = GetQueuedCompletionStatus
+//sys setFileCompletionNotificationModes(h windows.Handle, flags uint8) (err error) = SetFileCompletionNotificationModes
+//sys wsaGetOverlappedResult(h windows.Handle, o *windows.Overlapped, bytes *uint32, wait bool, flags *uint32) (err error) = ws2_32.WSAGetOverlappedResult
 
 //todo (go1.19): switch to [atomic.Bool]
 
@@ -52,7 +52,7 @@ func (*timeoutError) Temporary() bool { return true }
 type timeoutChan chan struct{}
 
 var ioInitOnce sync.Once
-var ioCompletionPort syscall.Handle
+var ioCompletionPort windows.Handle
 
 // ioResult contains the result of an asynchronous IO operation.
 type ioResult struct {
@@ -62,12 +62,12 @@ type ioResult struct {
 
 // ioOperation represents an outstanding asynchronous Win32 IO.
 type ioOperation struct {
-	o  syscall.Overlapped
+	o  windows.Overlapped
 	ch chan ioResult
 }
 
 func initIO() {
-	h, err := createIoCompletionPort(syscall.InvalidHandle, 0, 0, 0xffffffff)
+	h, err := createIoCompletionPort(windows.InvalidHandle, 0, 0, 0xffffffff)
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ func initIO() {
 // win32File implements Reader, Writer, and Closer on a Win32 handle without blocking in a syscall.
 // It takes ownership of this handle and will close it if it is garbage collected.
 type win32File struct {
-	handle        syscall.Handle
+	handle        windows.Handle
 	wg            sync.WaitGroup
 	wgLock        sync.RWMutex
 	closing       atomicBool
@@ -96,7 +96,7 @@ type deadlineHandler struct {
 }
 
 // makeWin32File makes a new win32File from an existing file handle.
-func makeWin32File(h syscall.Handle) (*win32File, error) {
+func makeWin32File(h windows.Handle) (*win32File, error) {
 	f := &win32File{handle: h}
 	ioInitOnce.Do(initIO)
 	_, err := createIoCompletionPort(h, ioCompletionPort, 0, 0xffffffff)
@@ -112,7 +112,12 @@ func makeWin32File(h syscall.Handle) (*win32File, error) {
 	return f, nil
 }
 
+// Deprecated: use NewOpenFile instead.
 func MakeOpenFile(h syscall.Handle) (io.ReadWriteCloser, error) {
+	return NewOpenFile(windows.Handle(h))
+}
+
+func NewOpenFile(h windows.Handle) (io.ReadWriteCloser, error) {
 	// If we return the result of makeWin32File directly, it can result in an
 	// interface-wrapped nil, rather than a nil interface value.
 	f, err := makeWin32File(h)
@@ -132,7 +137,7 @@ func (f *win32File) closeHandle() {
 		_ = cancelIoEx(f.handle, nil)
 		f.wg.Wait()
 		// at this point, no new IO can start
-		syscall.Close(f.handle)
+		windows.Close(f.handle)
 		f.handle = 0
 	} else {
 		f.wgLock.Unlock()
@@ -166,12 +171,12 @@ func (f *win32File) prepareIO() (*ioOperation, error) {
 }
 
 // ioCompletionProcessor processes completed async IOs forever.
-func ioCompletionProcessor(h syscall.Handle) {
+func ioCompletionProcessor(h windows.Handle) {
 	for {
 		var bytes uint32
 		var key uintptr
 		var op *ioOperation
-		err := getQueuedCompletionStatus(h, &bytes, &key, &op, syscall.INFINITE)
+		err := getQueuedCompletionStatus(h, &bytes, &key, &op, windows.INFINITE)
 		if op == nil {
 			panic(err)
 		}
@@ -184,7 +189,7 @@ func ioCompletionProcessor(h syscall.Handle) {
 // asyncIO processes the return value from ReadFile or WriteFile, blocking until
 // the operation has actually completed.
 func (f *win32File) asyncIO(c *ioOperation, d *deadlineHandler, bytes uint32, err error) (int, error) {
-	if err != syscall.ERROR_IO_PENDING { //nolint:errorlint // err is Errno
+	if err != windows.ERROR_IO_PENDING { //nolint:errorlint // err is Errno
 		return int(bytes), err
 	}
 
@@ -203,7 +208,7 @@ func (f *win32File) asyncIO(c *ioOperation, d *deadlineHandler, bytes uint32, er
 	select {
 	case r = <-c.ch:
 		err = r.err
-		if err == syscall.ERROR_OPERATION_ABORTED { //nolint:errorlint // err is Errno
+		if err == windows.ERROR_OPERATION_ABORTED { //nolint:errorlint // err is Errno
 			if f.closing.isSet() {
 				err = ErrFileClosed
 			}
@@ -216,7 +221,7 @@ func (f *win32File) asyncIO(c *ioOperation, d *deadlineHandler, bytes uint32, er
 		_ = cancelIoEx(f.handle, &c.o)
 		r = <-c.ch
 		err = r.err
-		if err == syscall.ERROR_OPERATION_ABORTED { //nolint:errorlint // err is Errno
+		if err == windows.ERROR_OPERATION_ABORTED { //nolint:errorlint // err is Errno
 			err = ErrTimeout
 		}
 	}
@@ -242,14 +247,14 @@ func (f *win32File) Read(b []byte) (int, error) {
 	}
 
 	var bytes uint32
-	err = syscall.ReadFile(f.handle, b, &bytes, &c.o)
+	err = windows.ReadFile(f.handle, b, &bytes, &c.o)
 	n, err := f.asyncIO(c, &f.readDeadline, bytes, err)
 	runtime.KeepAlive(b)
 
 	// Handle EOF conditions.
 	if err == nil && n == 0 && len(b) != 0 {
 		return 0, io.EOF
-	} else if err == syscall.ERROR_BROKEN_PIPE { //nolint:errorlint // err is Errno
+	} else if err == windows.ERROR_BROKEN_PIPE { //nolint:errorlint // err is Errno
 		return 0, io.EOF
 	} else {
 		return n, err
@@ -269,7 +274,7 @@ func (f *win32File) Write(b []byte) (int, error) {
 	}
 
 	var bytes uint32
-	err = syscall.WriteFile(f.handle, b, &bytes, &c.o)
+	err = windows.WriteFile(f.handle, b, &bytes, &c.o)
 	n, err := f.asyncIO(c, &f.writeDeadline, bytes, err)
 	runtime.KeepAlive(b)
 	return n, err
@@ -284,7 +289,7 @@ func (f *win32File) SetWriteDeadline(deadline time.Time) error {
 }
 
 func (f *win32File) Flush() error {
-	return syscall.FlushFileBuffers(f.handle)
+	return windows.FlushFileBuffers(f.handle)
 }
 
 func (f *win32File) Fd() uintptr {

--- a/hvsock.go
+++ b/hvsock.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -181,13 +180,13 @@ type HvsockConn struct {
 var _ net.Conn = &HvsockConn{}
 
 func newHVSocket() (*win32File, error) {
-	fd, err := syscall.Socket(afHVSock, syscall.SOCK_STREAM, 1)
+	fd, err := windows.Socket(afHVSock, windows.SOCK_STREAM, 1)
 	if err != nil {
 		return nil, os.NewSyscallError("socket", err)
 	}
 	f, err := makeWin32File(fd)
 	if err != nil {
-		syscall.Close(fd)
+		windows.Close(fd)
 		return nil, err
 	}
 	f.socket = true
@@ -202,11 +201,11 @@ func ListenHvsock(addr *HvsockAddr) (_ *HvsockListener, err error) {
 		return nil, l.opErr("listen", err)
 	}
 	sa := addr.raw()
-	err = socket.Bind(windows.Handle(sock.handle), &sa)
+	err = socket.Bind(sock.handle, &sa)
 	if err != nil {
 		return nil, l.opErr("listen", os.NewSyscallError("socket", err))
 	}
-	err = syscall.Listen(sock.handle, 16)
+	err = windows.Listen(sock.handle, 16)
 	if err != nil {
 		return nil, l.opErr("listen", os.NewSyscallError("listen", err))
 	}
@@ -246,7 +245,7 @@ func (l *HvsockListener) Accept() (_ net.Conn, err error) {
 	var addrbuf [addrlen * 2]byte
 
 	var bytes uint32
-	err = syscall.AcceptEx(l.sock.handle, sock.handle, &addrbuf[0], 0 /* rxdatalen */, addrlen, addrlen, &bytes, &c.o)
+	err = windows.AcceptEx(l.sock.handle, sock.handle, &addrbuf[0], 0 /* rxdatalen */, addrlen, addrlen, &bytes, &c.o)
 	if _, err = l.sock.asyncIO(c, nil, bytes, err); err != nil {
 		return nil, l.opErr("accept", os.NewSyscallError("acceptex", err))
 	}
@@ -263,7 +262,7 @@ func (l *HvsockListener) Accept() (_ net.Conn, err error) {
 	conn.remote.fromRaw((*rawHvsockAddr)(unsafe.Pointer(&addrbuf[addrlen])))
 
 	// initialize the accepted socket and update its properties with those of the listening socket
-	if err = windows.Setsockopt(windows.Handle(sock.handle),
+	if err = windows.Setsockopt(sock.handle,
 		windows.SOL_SOCKET, windows.SO_UPDATE_ACCEPT_CONTEXT,
 		(*byte)(unsafe.Pointer(&l.sock.handle)), int32(unsafe.Sizeof(l.sock.handle))); err != nil {
 		return nil, conn.opErr("accept", os.NewSyscallError("setsockopt", err))
@@ -334,7 +333,7 @@ func (d *HvsockDialer) Dial(ctx context.Context, addr *HvsockAddr) (conn *Hvsock
 	}()
 
 	sa := addr.raw()
-	err = socket.Bind(windows.Handle(sock.handle), &sa)
+	err = socket.Bind(sock.handle, &sa)
 	if err != nil {
 		return nil, conn.opErr(op, os.NewSyscallError("bind", err))
 	}
@@ -347,7 +346,7 @@ func (d *HvsockDialer) Dial(ctx context.Context, addr *HvsockAddr) (conn *Hvsock
 	var bytes uint32
 	for i := uint(0); i <= d.Retries; i++ {
 		err = socket.ConnectEx(
-			windows.Handle(sock.handle),
+			sock.handle,
 			&sa,
 			nil, // sendBuf
 			0,   // sendDataLen
@@ -367,7 +366,7 @@ func (d *HvsockDialer) Dial(ctx context.Context, addr *HvsockAddr) (conn *Hvsock
 
 	// update the connection properties, so shutdown can be used
 	if err = windows.Setsockopt(
-		windows.Handle(sock.handle),
+		sock.handle,
 		windows.SOL_SOCKET,
 		windows.SO_UPDATE_CONNECT_CONTEXT,
 		nil, // optvalue
@@ -378,7 +377,7 @@ func (d *HvsockDialer) Dial(ctx context.Context, addr *HvsockAddr) (conn *Hvsock
 
 	// get the local name
 	var sal rawHvsockAddr
-	err = socket.GetSockName(windows.Handle(sock.handle), &sal)
+	err = socket.GetSockName(sock.handle, &sal)
 	if err != nil {
 		return nil, conn.opErr(op, os.NewSyscallError("getsockname", err))
 	}
@@ -421,7 +420,7 @@ func (d *HvsockDialer) redialWait(ctx context.Context) (err error) {
 	return ctx.Err()
 }
 
-// assumes error is a plain, unwrapped syscall.Errno provided by direct syscall.
+// assumes error is a plain, unwrapped windows.Errno provided by direct syscall.
 func canRedial(err error) bool {
 	//nolint:errorlint // guaranteed to be an Errno
 	switch err {
@@ -447,9 +446,9 @@ func (conn *HvsockConn) Read(b []byte) (int, error) {
 		return 0, conn.opErr("read", err)
 	}
 	defer conn.sock.wg.Done()
-	buf := syscall.WSABuf{Buf: &b[0], Len: uint32(len(b))}
+	buf := windows.WSABuf{Buf: &b[0], Len: uint32(len(b))}
 	var flags, bytes uint32
-	err = syscall.WSARecv(conn.sock.handle, &buf, 1, &bytes, &flags, &c.o, nil)
+	err = windows.WSARecv(conn.sock.handle, &buf, 1, &bytes, &flags, &c.o, nil)
 	n, err := conn.sock.asyncIO(c, &conn.sock.readDeadline, bytes, err)
 	if err != nil {
 		var eno windows.Errno
@@ -482,9 +481,9 @@ func (conn *HvsockConn) write(b []byte) (int, error) {
 		return 0, conn.opErr("write", err)
 	}
 	defer conn.sock.wg.Done()
-	buf := syscall.WSABuf{Buf: &b[0], Len: uint32(len(b))}
+	buf := windows.WSABuf{Buf: &b[0], Len: uint32(len(b))}
 	var bytes uint32
-	err = syscall.WSASend(conn.sock.handle, &buf, 1, &bytes, 0, &c.o, nil)
+	err = windows.WSASend(conn.sock.handle, &buf, 1, &bytes, 0, &c.o, nil)
 	n, err := conn.sock.asyncIO(c, &conn.sock.writeDeadline, bytes, err)
 	if err != nil {
 		var eno windows.Errno
@@ -511,7 +510,7 @@ func (conn *HvsockConn) shutdown(how int) error {
 		return socket.ErrSocketClosed
 	}
 
-	err := syscall.Shutdown(conn.sock.handle, how)
+	err := windows.Shutdown(conn.sock.handle, how)
 	if err != nil {
 		// If the connection was closed, shutdowns fail with "not connected"
 		if errors.Is(err, windows.WSAENOTCONN) ||
@@ -525,7 +524,7 @@ func (conn *HvsockConn) shutdown(how int) error {
 
 // CloseRead shuts down the read end of the socket, preventing future read operations.
 func (conn *HvsockConn) CloseRead() error {
-	err := conn.shutdown(syscall.SHUT_RD)
+	err := conn.shutdown(windows.SHUT_RD)
 	if err != nil {
 		return conn.opErr("closeread", err)
 	}
@@ -535,7 +534,7 @@ func (conn *HvsockConn) CloseRead() error {
 // CloseWrite shuts down the write end of the socket, preventing future write operations and
 // notifying the other endpoint that no more data will be written.
 func (conn *HvsockConn) CloseWrite() error {
-	err := conn.shutdown(syscall.SHUT_WR)
+	err := conn.shutdown(windows.SHUT_WR)
 	if err != nil {
 		return conn.opErr("closewrite", err)
 	}

--- a/hvsock_test.go
+++ b/hvsock_test.go
@@ -114,7 +114,7 @@ func TestHvSockListenerAddresses(t *testing.T) {
 
 	ra := rawHvsockAddr{}
 	sa := HvsockAddr{}
-	u.Must(socket.GetSockName(windows.Handle(l.sock.handle), &ra))
+	u.Must(socket.GetSockName(l.sock.handle, &ra))
 	sa.fromRaw(&ra)
 	u.Assert(sa == *addr, fmt.Sprintf("listener local addr give: %v; want: %v", sa, addr))
 }
@@ -162,7 +162,7 @@ func TestHvSockAddresses(t *testing.T) {
 			// {"server", sv.sock, _sla},
 		}
 		for _, tt := range localTests {
-			u.Must(socket.GetSockName(windows.Handle(tt.giveSock.handle), &ra))
+			u.Must(socket.GetSockName(tt.giveSock.handle, &ra))
 			sa.fromRaw(&ra)
 			if sa != tt.wantAddr {
 				t.Errorf("%s local addr give: %v; want: %v", tt.name, sa, tt.wantAddr)
@@ -177,7 +177,7 @@ func TestHvSockAddresses(t *testing.T) {
 			{"server", sv},
 		}
 		for _, tt := range remoteTests {
-			u.Must(socket.GetPeerName(windows.Handle(tt.giveConn.sock.handle), &ra))
+			u.Must(socket.GetPeerName(tt.giveConn.sock.handle, &ra))
 			sa.fromRaw(&ra)
 			if sa != tt.giveConn.remote {
 				t.Errorf("%s remote addr give: %v; want: %v", tt.name, sa, tt.giveConn.remote)

--- a/internal/fs/zsyscall_windows.go
+++ b/internal/fs/zsyscall_windows.go
@@ -45,7 +45,7 @@ var (
 	procCreateFileW = modkernel32.NewProc("CreateFileW")
 )
 
-func CreateFile(name string, access AccessMask, mode FileShareMode, sa *syscall.SecurityAttributes, createmode FileCreationDisposition, attrs FileFlagOrAttribute, templatefile windows.Handle) (handle windows.Handle, err error) {
+func CreateFile(name string, access AccessMask, mode FileShareMode, sa *windows.SecurityAttributes, createmode FileCreationDisposition, attrs FileFlagOrAttribute, templatefile windows.Handle) (handle windows.Handle, err error) {
 	var _p0 *uint16
 	_p0, err = syscall.UTF16PtrFromString(name)
 	if err != nil {
@@ -54,7 +54,7 @@ func CreateFile(name string, access AccessMask, mode FileShareMode, sa *syscall.
 	return _CreateFile(_p0, access, mode, sa, createmode, attrs, templatefile)
 }
 
-func _CreateFile(name *uint16, access AccessMask, mode FileShareMode, sa *syscall.SecurityAttributes, createmode FileCreationDisposition, attrs FileFlagOrAttribute, templatefile windows.Handle) (handle windows.Handle, err error) {
+func _CreateFile(name *uint16, access AccessMask, mode FileShareMode, sa *windows.SecurityAttributes, createmode FileCreationDisposition, attrs FileFlagOrAttribute, templatefile windows.Handle) (handle windows.Handle, err error) {
 	r0, _, e1 := syscall.Syscall9(procCreateFileW.Addr(), 7, uintptr(unsafe.Pointer(name)), uintptr(access), uintptr(mode), uintptr(unsafe.Pointer(sa)), uintptr(createmode), uintptr(attrs), uintptr(templatefile), 0, 0)
 	handle = windows.Handle(r0)
 	if handle == windows.InvalidHandle {

--- a/pipe.go
+++ b/pipe.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -20,13 +19,12 @@ import (
 	"github.com/Microsoft/go-winio/internal/fs"
 )
 
-//sys connectNamedPipe(pipe syscall.Handle, o *syscall.Overlapped) (err error) = ConnectNamedPipe
-//sys createNamedPipe(name string, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *syscall.SecurityAttributes) (handle syscall.Handle, err error)  [failretval==syscall.InvalidHandle] = CreateNamedPipeW
-//sys disconnectNamedPipe(pipe syscall.Handle) (err error) = DisconnectNamedPipe
-//sys getNamedPipeInfo(pipe syscall.Handle, flags *uint32, outSize *uint32, inSize *uint32, maxInstances *uint32) (err error) = GetNamedPipeInfo
-//sys getNamedPipeHandleState(pipe syscall.Handle, state *uint32, curInstances *uint32, maxCollectionCount *uint32, collectDataTimeout *uint32, userName *uint16, maxUserNameSize uint32) (err error) = GetNamedPipeHandleStateW
-//sys localAlloc(uFlags uint32, length uint32) (ptr uintptr) = LocalAlloc
-//sys ntCreateNamedPipeFile(pipe *syscall.Handle, access uint32, oa *objectAttributes, iosb *ioStatusBlock, share uint32, disposition uint32, options uint32, typ uint32, readMode uint32, completionMode uint32, maxInstances uint32, inboundQuota uint32, outputQuota uint32, timeout *int64) (status ntStatus) = ntdll.NtCreateNamedPipeFile
+//sys connectNamedPipe(pipe windows.Handle, o *windows.Overlapped) (err error) = ConnectNamedPipe
+//sys createNamedPipe(name string, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *windows.SecurityAttributes) (handle windows.Handle, err error)  [failretval==windows.InvalidHandle] = CreateNamedPipeW
+//sys disconnectNamedPipe(pipe windows.Handle) (err error) = DisconnectNamedPipe
+//sys getNamedPipeInfo(pipe windows.Handle, flags *uint32, outSize *uint32, inSize *uint32, maxInstances *uint32) (err error) = GetNamedPipeInfo
+//sys getNamedPipeHandleState(pipe windows.Handle, state *uint32, curInstances *uint32, maxCollectionCount *uint32, collectDataTimeout *uint32, userName *uint16, maxUserNameSize uint32) (err error) = GetNamedPipeHandleStateW
+//sys ntCreateNamedPipeFile(pipe *windows.Handle, access ntAccessMask, oa *objectAttributes, iosb *ioStatusBlock, share ntFileShareMode, disposition ntFileCreationDisposition, options ntFileOptions, typ uint32, readMode uint32, completionMode uint32, maxInstances uint32, inboundQuota uint32, outputQuota uint32, timeout *int64) (status ntStatus) = ntdll.NtCreateNamedPipeFile
 //sys rtlNtStatusToDosError(status ntStatus) (winerr error) = ntdll.RtlNtStatusToDosErrorNoTeb
 //sys rtlDosPathNameToNtPathName(name *uint16, ntName *unicodeString, filePart uintptr, reserved uintptr) (status ntStatus) = ntdll.RtlDosPathNameToNtPathName_U
 //sys rtlDefaultNpAcl(dacl *uintptr) (status ntStatus) = ntdll.RtlDefaultNpAcl
@@ -37,10 +35,28 @@ type PipeConn interface {
 	Flush() error
 }
 
+// type aliases for mkwinsyscall code
+type (
+	ntAccessMask              = fs.AccessMask
+	ntFileShareMode           = fs.FileShareMode
+	ntFileCreationDisposition = fs.NTFileCreationDisposition
+	ntFileOptions             = fs.NTCreateOptions
+)
+
 type ioStatusBlock struct {
 	Status, Information uintptr
 }
 
+//	typedef struct _OBJECT_ATTRIBUTES {
+//	  ULONG           Length;
+//	  HANDLE          RootDirectory;
+//	  PUNICODE_STRING ObjectName;
+//	  ULONG           Attributes;
+//	  PVOID           SecurityDescriptor;
+//	  PVOID           SecurityQualityOfService;
+//	} OBJECT_ATTRIBUTES;
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/ntdef/ns-ntdef-_object_attributes
 type objectAttributes struct {
 	Length             uintptr
 	RootDirectory      uintptr
@@ -56,6 +72,17 @@ type unicodeString struct {
 	Buffer        uintptr
 }
 
+//	typedef struct _SECURITY_DESCRIPTOR {
+//	  BYTE                        Revision;
+//	  BYTE                        Sbz1;
+//	  SECURITY_DESCRIPTOR_CONTROL Control;
+//	  PSID                        Owner;
+//	  PSID                        Group;
+//	  PACL                        Sacl;
+//	  PACL                        Dacl;
+//	} SECURITY_DESCRIPTOR, *PISECURITY_DESCRIPTOR;
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-security_descriptor
 type securityDescriptor struct {
 	Revision byte
 	Sbz1     byte
@@ -159,7 +186,7 @@ func (f *win32MessageBytePipe) Read(b []byte) (int, error) {
 		// zero-byte message, ensure that all future Read() calls
 		// also return EOF.
 		f.readEOF = true
-	} else if err == syscall.ERROR_MORE_DATA { //nolint:errorlint // err is Errno
+	} else if err == windows.ERROR_MORE_DATA { //nolint:errorlint // err is Errno
 		// ERROR_MORE_DATA indicates that the pipe's read mode is message mode
 		// and the message still has more bytes. Treat this as a success, since
 		// this package presents all named pipes as byte streams.
@@ -177,13 +204,13 @@ func (s pipeAddress) String() string {
 }
 
 // tryDialPipe attempts to dial the pipe at `path` until `ctx` cancellation or timeout.
-func tryDialPipe(ctx context.Context, path *string, access fs.AccessMask) (syscall.Handle, error) {
+func tryDialPipe(ctx context.Context, path *string, access fs.AccessMask) (windows.Handle, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return syscall.Handle(0), ctx.Err()
+			return windows.Handle(0), ctx.Err()
 		default:
-			wh, err := fs.CreateFile(*path,
+			h, err := fs.CreateFile(*path,
 				access,
 				0,   // mode
 				nil, // security attributes
@@ -191,7 +218,6 @@ func tryDialPipe(ctx context.Context, path *string, access fs.AccessMask) (sysca
 				fs.FILE_FLAG_OVERLAPPED|fs.SECURITY_SQOS_PRESENT|fs.SECURITY_ANONYMOUS,
 				0, // template file handle
 			)
-			h := syscall.Handle(wh)
 			if err == nil {
 				return h, nil
 			}
@@ -227,14 +253,14 @@ func DialPipe(path string, timeout *time.Duration) (net.Conn, error) {
 // DialPipeContext attempts to connect to a named pipe by `path` until `ctx`
 // cancellation or timeout.
 func DialPipeContext(ctx context.Context, path string) (net.Conn, error) {
-	return DialPipeAccess(ctx, path, syscall.GENERIC_READ|syscall.GENERIC_WRITE)
+	return DialPipeAccess(ctx, path, uint32(fs.GENERIC_READ|fs.GENERIC_WRITE))
 }
 
 // DialPipeAccess attempts to connect to a named pipe by `path` with `access` until `ctx`
 // cancellation or timeout.
 func DialPipeAccess(ctx context.Context, path string, access uint32) (net.Conn, error) {
 	var err error
-	var h syscall.Handle
+	var h windows.Handle
 	h, err = tryDialPipe(ctx, &path, fs.AccessMask(access))
 	if err != nil {
 		return nil, err
@@ -248,7 +274,7 @@ func DialPipeAccess(ctx context.Context, path string, access uint32) (net.Conn, 
 
 	f, err := makeWin32File(h)
 	if err != nil {
-		syscall.Close(h)
+		windows.Close(h)
 		return nil, err
 	}
 
@@ -268,7 +294,7 @@ type acceptResponse struct {
 }
 
 type win32PipeListener struct {
-	firstHandle syscall.Handle
+	firstHandle windows.Handle
 	path        string
 	config      PipeConfig
 	acceptCh    chan (chan acceptResponse)
@@ -276,8 +302,8 @@ type win32PipeListener struct {
 	doneCh      chan int
 }
 
-func makeServerPipeHandle(path string, sd []byte, c *PipeConfig, first bool) (syscall.Handle, error) {
-	path16, err := syscall.UTF16FromString(path)
+func makeServerPipeHandle(path string, sd []byte, c *PipeConfig, first bool) (windows.Handle, error) {
+	path16, err := windows.UTF16FromString(path)
 	if err != nil {
 		return 0, &os.PathError{Op: "open", Path: path, Err: err}
 	}
@@ -293,16 +319,20 @@ func makeServerPipeHandle(path string, sd []byte, c *PipeConfig, first bool) (sy
 	).Err(); err != nil {
 		return 0, &os.PathError{Op: "open", Path: path, Err: err}
 	}
-	defer localFree(ntPath.Buffer)
+	defer windows.LocalFree(windows.Handle(ntPath.Buffer)) //nolint:errcheck
 	oa.ObjectName = &ntPath
 	oa.Attributes = windows.OBJ_CASE_INSENSITIVE
 
 	// The security descriptor is only needed for the first pipe.
 	if first {
 		if sd != nil {
+			//todo: does `sdb` need to be allocated on the heap, or can go allocate it?
 			l := uint32(len(sd))
-			sdb := localAlloc(0, l)
-			defer localFree(sdb)
+			sdb, err := windows.LocalAlloc(0, l)
+			if err != nil {
+				return 0, fmt.Errorf("LocalAlloc for security descriptor with of length %d: %w", l, err)
+			}
+			defer windows.LocalFree(windows.Handle(sdb)) //nolint:errcheck
 			copy((*[0xffff]byte)(unsafe.Pointer(sdb))[:], sd)
 			oa.SecurityDescriptor = (*securityDescriptor)(unsafe.Pointer(sdb))
 		} else {
@@ -311,7 +341,7 @@ func makeServerPipeHandle(path string, sd []byte, c *PipeConfig, first bool) (sy
 			if err := rtlDefaultNpAcl(&dacl).Err(); err != nil {
 				return 0, fmt.Errorf("getting default named pipe ACL: %w", err)
 			}
-			defer localFree(dacl)
+			defer windows.LocalFree(windows.Handle(dacl)) //nolint:errcheck
 
 			sdb := &securityDescriptor{
 				Revision: 1,
@@ -327,27 +357,27 @@ func makeServerPipeHandle(path string, sd []byte, c *PipeConfig, first bool) (sy
 		typ |= windows.FILE_PIPE_MESSAGE_TYPE
 	}
 
-	disposition := uint32(windows.FILE_OPEN)
-	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE | syscall.SYNCHRONIZE)
+	disposition := fs.FILE_OPEN
+	access := fs.GENERIC_READ | fs.GENERIC_WRITE | fs.SYNCHRONIZE
 	if first {
-		disposition = windows.FILE_CREATE
+		disposition = fs.FILE_CREATE
 		// By not asking for read or write access, the named pipe file system
 		// will put this pipe into an initially disconnected state, blocking
 		// client connections until the next call with first == false.
-		access = syscall.SYNCHRONIZE
+		access = fs.SYNCHRONIZE
 	}
 
 	timeout := int64(-50 * 10000) // 50ms
 
 	var (
-		h    syscall.Handle
+		h    windows.Handle
 		iosb ioStatusBlock
 	)
 	err = ntCreateNamedPipeFile(&h,
 		access,
 		&oa,
 		&iosb,
-		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		fs.FILE_SHARE_READ|fs.FILE_SHARE_WRITE,
 		disposition,
 		0,
 		typ,
@@ -372,7 +402,7 @@ func (l *win32PipeListener) makeServerPipe() (*win32File, error) {
 	}
 	f, err := makeWin32File(h)
 	if err != nil {
-		syscall.Close(h)
+		windows.Close(h)
 		return nil, err
 	}
 	return f, nil
@@ -431,7 +461,7 @@ func (l *win32PipeListener) listenerRoutine() {
 			closed = err == ErrPipeListenerClosed //nolint:errorlint // err is Errno
 		}
 	}
-	syscall.Close(l.firstHandle)
+	windows.Close(l.firstHandle)
 	l.firstHandle = 0
 	// Notify Close() and Accept() callers that the handle has been closed.
 	close(l.doneCh)

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 	"unsafe"
@@ -25,8 +24,8 @@ var aLongTimeAgo = time.Unix(1, 0)
 
 func TestDialUnknownFailsImmediately(t *testing.T) {
 	_, err := DialPipe(testPipeName, nil)
-	if !errors.Is(err, syscall.ENOENT) {
-		t.Fatalf("expected ENOENT got %v", err)
+	if !errors.Is(err, windows.ERROR_FILE_NOT_FOUND) {
+		t.Fatalf("expected ERROR_FILE_NOT_FOUND got %v", err)
 	}
 }
 
@@ -88,7 +87,7 @@ func TestDialAccessDeniedWithRestrictedSD(t *testing.T) {
 	}
 	defer l.Close()
 	_, err = DialPipe(testPipeName, nil)
-	if !errors.Is(err, syscall.ERROR_ACCESS_DENIED) {
+	if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
 		t.Fatalf("expected ERROR_ACCESS_DENIED, got %v", err)
 	}
 }
@@ -596,7 +595,7 @@ func TestMessageReadMode(t *testing.T) {
 	}
 	defer c.Close()
 
-	setNamedPipeHandleState := syscall.NewLazyDLL("kernel32.dll").NewProc("SetNamedPipeHandleState")
+	setNamedPipeHandleState := windows.NewLazyDLL("kernel32.dll").NewProc("SetNamedPipeHandleState")
 
 	p := c.(*win32MessageBytePipe)
 	mode := uint32(windows.PIPE_READMODE_MESSAGE)

--- a/pkg/bindfilter/bind_filter.go
+++ b/pkg/bindfilter/bind_filter.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -244,7 +243,7 @@ func getFinalPath(pth string) (string, error) {
 		}
 		buf = make([]uint16, n)
 	}
-	finalPath := syscall.UTF16ToString(buf)
+	finalPath := windows.UTF16ToString(buf)
 	// We got VOLUME_NAME_DOS, we need to strip away some leading slashes.
 	// Leave unchanged if we ended up requesting VOLUME_NAME_GUID
 	if len(finalPath) > 4 && finalPath[:4] == `\\?\` && flags == 0x0 {

--- a/pkg/etw/eventdata.go
+++ b/pkg/etw/eventdata.go
@@ -6,7 +6,8 @@ package etw
 import (
 	"bytes"
 	"encoding/binary"
-	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // eventData maintains a buffer which builds up the data for an ETW event. It
@@ -69,6 +70,6 @@ func (ed *eventData) writeUint64(value uint64) {
 }
 
 // writeFiletime appends a FILETIME to the buffer.
-func (ed *eventData) writeFiletime(value syscall.Filetime) {
+func (ed *eventData) writeFiletime(value windows.Filetime) {
 	_ = binary.Write(&ed.buffer, binary.LittleEndian, value)
 }

--- a/pkg/etw/fieldopt.go
+++ b/pkg/etw/fieldopt.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // FieldOpt defines the option function type that can be passed to
@@ -397,7 +398,7 @@ func Struct(name string, opts ...FieldOpt) FieldOpt {
 func Time(name string, value time.Time) FieldOpt {
 	return func(em *eventMetadata, ed *eventData) {
 		em.writeField(name, inTypeFileTime, outTypeDateTimeUTC, 0)
-		ed.writeFiletime(syscall.NsecToFiletime(value.UTC().UnixNano()))
+		ed.writeFiletime(windows.NsecToFiletime(value.UTC().UnixNano()))
 	}
 }
 

--- a/pkg/security/grantvmgroupaccess.go
+++ b/pkg/security/grantvmgroupaccess.go
@@ -6,8 +6,9 @@ package security
 import (
 	"fmt"
 	"os"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 type (
@@ -83,7 +84,7 @@ func GrantVmGroupAccess(name string) error {
 	if err != nil {
 		return err // Already wrapped
 	}
-	defer syscall.CloseHandle(fd) //nolint:errcheck
+	defer windows.CloseHandle(fd) //nolint:errcheck
 
 	// Get the current DACL and Security Descriptor. Must defer LocalFree on success.
 	ot := objectTypeFileObject
@@ -93,7 +94,7 @@ func GrantVmGroupAccess(name string) error {
 	if err := getSecurityInfo(fd, uint32(ot), uint32(si), nil, nil, &origDACL, nil, &sd); err != nil {
 		return fmt.Errorf("%s GetSecurityInfo %s: %w", gvmga, name, err)
 	}
-	defer syscall.LocalFree((syscall.Handle)(unsafe.Pointer(sd))) //nolint:errcheck
+	defer windows.LocalFree(windows.Handle(sd)) //nolint:errcheck
 
 	// Generate a new DACL which is the current DACL with the required ACEs added.
 	// Must defer LocalFree on success.
@@ -101,7 +102,7 @@ func GrantVmGroupAccess(name string) error {
 	if err != nil {
 		return err // Already wrapped
 	}
-	defer syscall.LocalFree((syscall.Handle)(unsafe.Pointer(newDACL))) //nolint:errcheck
+	defer windows.LocalFree(windows.Handle(newDACL)) //nolint:errcheck
 
 	// And finally use SetSecurityInfo to apply the updated DACL.
 	if err := setSecurityInfo(fd, uint32(ot), uint32(si), uintptr(0), uintptr(0), newDACL, uintptr(0)); err != nil {
@@ -113,20 +114,20 @@ func GrantVmGroupAccess(name string) error {
 
 // createFile is a helper function to call [Nt]CreateFile to get a handle to
 // the file or directory.
-func createFile(name string, isDir bool) (syscall.Handle, error) {
-	namep, err := syscall.UTF16FromString(name)
+func createFile(name string, isDir bool) (windows.Handle, error) {
+	namep, err := windows.UTF16FromString(name)
 	if err != nil {
-		return syscall.InvalidHandle, fmt.Errorf("could not convernt name to UTF-16: %w", err)
+		return windows.InvalidHandle, fmt.Errorf("could not convernt name to UTF-16: %w", err)
 	}
 	da := uint32(desiredAccessReadControl | desiredAccessWriteDac)
 	sm := uint32(shareModeRead | shareModeWrite)
-	fa := uint32(syscall.FILE_ATTRIBUTE_NORMAL)
+	fa := uint32(windows.FILE_ATTRIBUTE_NORMAL)
 	if isDir {
-		fa |= syscall.FILE_FLAG_BACKUP_SEMANTICS
+		fa |= windows.FILE_FLAG_BACKUP_SEMANTICS
 	}
-	fd, err := syscall.CreateFile(&namep[0], da, sm, nil, syscall.OPEN_EXISTING, fa, 0)
+	fd, err := windows.CreateFile(&namep[0], da, sm, nil, windows.OPEN_EXISTING, fa, 0)
 	if err != nil {
-		return syscall.InvalidHandle, fmt.Errorf("%s syscall.CreateFile %s: %w", gvmga, name, err)
+		return windows.InvalidHandle, fmt.Errorf("%s windows.CreateFile %s: %w", gvmga, name, err)
 	}
 	return fd, nil
 }
@@ -135,9 +136,9 @@ func createFile(name string, isDir bool) (syscall.Handle, error) {
 // The caller is responsible for LocalFree of the returned DACL on success.
 func generateDACLWithAcesAdded(name string, isDir bool, origDACL uintptr) (uintptr, error) {
 	// Generate pointers to the SIDs based on the string SIDs
-	sid, err := syscall.StringToSid(sidVMGroup)
+	sid, err := windows.StringToSid(sidVMGroup)
 	if err != nil {
-		return 0, fmt.Errorf("%s syscall.StringToSid %s %s: %w", gvmga, name, sidVMGroup, err)
+		return 0, fmt.Errorf("%s windows.StringToSid %s %s: %w", gvmga, name, sidVMGroup, err)
 	}
 
 	inheritance := inheritModeNoInheritance

--- a/pkg/security/syscall_windows.go
+++ b/pkg/security/syscall_windows.go
@@ -2,6 +2,6 @@ package security
 
 //go:generate go run github.com/Microsoft/go-winio/tools/mkwinsyscall -output zsyscall_windows.go syscall_windows.go
 
-//sys getSecurityInfo(handle syscall.Handle, objectType uint32, si uint32, ppsidOwner **uintptr, ppsidGroup **uintptr, ppDacl *uintptr, ppSacl *uintptr, ppSecurityDescriptor *uintptr) (win32err error) = advapi32.GetSecurityInfo
-//sys setSecurityInfo(handle syscall.Handle, objectType uint32, si uint32, psidOwner uintptr, psidGroup uintptr, pDacl uintptr, pSacl uintptr) (win32err error) = advapi32.SetSecurityInfo
+//sys getSecurityInfo(handle windows.Handle, objectType uint32, si uint32, ppsidOwner **uintptr, ppsidGroup **uintptr, ppDacl *uintptr, ppSacl *uintptr, ppSecurityDescriptor *uintptr) (win32err error) = advapi32.GetSecurityInfo
+//sys setSecurityInfo(handle windows.Handle, objectType uint32, si uint32, psidOwner uintptr, psidGroup uintptr, pDacl uintptr, pSacl uintptr) (win32err error) = advapi32.SetSecurityInfo
 //sys setEntriesInAcl(count uintptr, pListOfEEs uintptr, oldAcl uintptr, newAcl *uintptr) (win32err error) = advapi32.SetEntriesInAclW

--- a/pkg/security/zsyscall_windows.go
+++ b/pkg/security/zsyscall_windows.go
@@ -47,7 +47,7 @@ var (
 	procSetSecurityInfo  = modadvapi32.NewProc("SetSecurityInfo")
 )
 
-func getSecurityInfo(handle syscall.Handle, objectType uint32, si uint32, ppsidOwner **uintptr, ppsidGroup **uintptr, ppDacl *uintptr, ppSacl *uintptr, ppSecurityDescriptor *uintptr) (win32err error) {
+func getSecurityInfo(handle windows.Handle, objectType uint32, si uint32, ppsidOwner **uintptr, ppsidGroup **uintptr, ppDacl *uintptr, ppSacl *uintptr, ppSecurityDescriptor *uintptr) (win32err error) {
 	r0, _, _ := syscall.Syscall9(procGetSecurityInfo.Addr(), 8, uintptr(handle), uintptr(objectType), uintptr(si), uintptr(unsafe.Pointer(ppsidOwner)), uintptr(unsafe.Pointer(ppsidGroup)), uintptr(unsafe.Pointer(ppDacl)), uintptr(unsafe.Pointer(ppSacl)), uintptr(unsafe.Pointer(ppSecurityDescriptor)), 0)
 	if r0 != 0 {
 		win32err = syscall.Errno(r0)
@@ -63,7 +63,7 @@ func setEntriesInAcl(count uintptr, pListOfEEs uintptr, oldAcl uintptr, newAcl *
 	return
 }
 
-func setSecurityInfo(handle syscall.Handle, objectType uint32, si uint32, psidOwner uintptr, psidGroup uintptr, pDacl uintptr, pSacl uintptr) (win32err error) {
+func setSecurityInfo(handle windows.Handle, objectType uint32, si uint32, psidOwner uintptr, psidGroup uintptr, pDacl uintptr, pSacl uintptr) (win32err error) {
 	r0, _, _ := syscall.Syscall9(procSetSecurityInfo.Addr(), 7, uintptr(handle), uintptr(objectType), uintptr(si), uintptr(psidOwner), uintptr(psidGroup), uintptr(pDacl), uintptr(pSacl), 0, 0)
 	if r0 != 0 {
 		win32err = syscall.Errno(r0)

--- a/privilege.go
+++ b/privilege.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
-	"syscall"
 	"unicode/utf16"
 
 	"golang.org/x/sys/windows"
@@ -18,8 +17,8 @@ import (
 //sys adjustTokenPrivileges(token windows.Token, releaseAll bool, input *byte, outputSize uint32, output *byte, requiredSize *uint32) (success bool, err error) [true] = advapi32.AdjustTokenPrivileges
 //sys impersonateSelf(level uint32) (err error) = advapi32.ImpersonateSelf
 //sys revertToSelf() (err error) = advapi32.RevertToSelf
-//sys openThreadToken(thread syscall.Handle, accessMask uint32, openAsSelf bool, token *windows.Token) (err error) = advapi32.OpenThreadToken
-//sys getCurrentThread() (h syscall.Handle) = GetCurrentThread
+//sys openThreadToken(thread windows.Handle, accessMask uint32, openAsSelf bool, token *windows.Token) (err error) = advapi32.OpenThreadToken
+//sys getCurrentThread() (h windows.Handle) = GetCurrentThread
 //sys lookupPrivilegeValue(systemName string, name string, luid *uint64) (err error) = advapi32.LookupPrivilegeValueW
 //sys lookupPrivilegeName(systemName string, luid *uint64, buffer *uint16, size *uint32) (err error) = advapi32.LookupPrivilegeNameW
 //sys lookupPrivilegeDisplayName(systemName string, name *uint16, buffer *uint16, size *uint32, languageId *uint32) (err error) = advapi32.LookupPrivilegeDisplayNameW
@@ -29,7 +28,7 @@ const (
 	SE_PRIVILEGE_ENABLED = windows.SE_PRIVILEGE_ENABLED
 
 	//revive:disable-next-line:var-naming ALL_CAPS
-	ERROR_NOT_ALL_ASSIGNED syscall.Errno = windows.ERROR_NOT_ALL_ASSIGNED
+	ERROR_NOT_ALL_ASSIGNED windows.Errno = windows.ERROR_NOT_ALL_ASSIGNED
 
 	SeBackupPrivilege   = "SeBackupPrivilege"
 	SeRestorePrivilege  = "SeRestorePrivilege"
@@ -177,7 +176,7 @@ func newThreadToken() (windows.Token, error) {
 	}
 
 	var token windows.Token
-	err = openThreadToken(getCurrentThread(), syscall.TOKEN_ADJUST_PRIVILEGES|syscall.TOKEN_QUERY, false, &token)
+	err = openThreadToken(getCurrentThread(), windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, false, &token)
 	if err != nil {
 		rerr := revertToSelf()
 		if rerr != nil {

--- a/sd.go
+++ b/sd.go
@@ -5,7 +5,7 @@ package winio
 
 import (
 	"errors"
-	"syscall"
+	"fmt"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -15,9 +15,6 @@ import (
 //sys lookupAccountSid(systemName *uint16, sid *byte, name *uint16, nameSize *uint32, refDomain *uint16, refDomainSize *uint32, sidNameUse *uint32) (err error) = advapi32.LookupAccountSidW
 //sys convertSidToStringSid(sid *byte, str **uint16) (err error) = advapi32.ConvertSidToStringSidW
 //sys convertStringSidToSid(str *uint16, sid **byte) (err error) = advapi32.ConvertStringSidToSidW
-//sys convertStringSecurityDescriptorToSecurityDescriptor(str string, revision uint32, sd *uintptr, size *uint32) (err error) = advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW
-//sys convertSecurityDescriptorToStringSecurityDescriptor(sd *byte, revision uint32, secInfo uint32, sddl **uint16, sddlSize *uint32) (err error) = advapi32.ConvertSecurityDescriptorToStringSecurityDescriptorW
-//sys localFree(mem uintptr) = LocalFree
 //sys getSecurityDescriptorLength(sd uintptr) (len uint32) = advapi32.GetSecurityDescriptorLength
 
 type AccountLookupError struct {
@@ -64,7 +61,7 @@ func LookupSidByName(name string) (sid string, err error) {
 
 	var sidSize, sidNameUse, refDomainSize uint32
 	err = lookupAccountName(nil, name, nil, &sidSize, nil, &refDomainSize, &sidNameUse)
-	if err != nil && err != syscall.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // err is Errno
+	if err != nil && err != windows.ERROR_INSUFFICIENT_BUFFER { //nolint:errorlint // err is Errno
 		return "", &AccountLookupError{name, err}
 	}
 	sidBuffer := make([]byte, sidSize)
@@ -78,8 +75,8 @@ func LookupSidByName(name string) (sid string, err error) {
 	if err != nil {
 		return "", &AccountLookupError{name, err}
 	}
-	sid = syscall.UTF16ToString((*[0xffff]uint16)(unsafe.Pointer(strBuffer))[:])
-	localFree(uintptr(unsafe.Pointer(strBuffer)))
+	sid = windows.UTF16ToString((*[0xffff]uint16)(unsafe.Pointer(strBuffer))[:])
+	_, _ = windows.LocalFree(windows.Handle(unsafe.Pointer(strBuffer)))
 	return sid, nil
 }
 
@@ -100,7 +97,7 @@ func LookupNameBySid(sid string) (name string, err error) {
 	if err = convertStringSidToSid(sidBuffer, &sidPtr); err != nil {
 		return "", &AccountLookupError{sid, err}
 	}
-	defer localFree(uintptr(unsafe.Pointer(sidPtr)))
+	defer windows.LocalFree(windows.Handle(unsafe.Pointer(sidPtr))) //nolint:errcheck
 
 	var nameSize, refDomainSize, sidNameUse uint32
 	err = lookupAccountSid(nil, sidPtr, nil, &nameSize, nil, &refDomainSize, &sidNameUse)
@@ -120,25 +117,18 @@ func LookupNameBySid(sid string) (name string, err error) {
 }
 
 func SddlToSecurityDescriptor(sddl string) ([]byte, error) {
-	var sdBuffer uintptr
-	err := convertStringSecurityDescriptorToSecurityDescriptor(sddl, 1, &sdBuffer, nil)
+	sd, err := windows.SecurityDescriptorFromString(sddl)
 	if err != nil {
-		return nil, &SddlConversionError{sddl, err}
+		return nil, &SddlConversionError{Sddl: sddl, Err: err}
 	}
-	defer localFree(sdBuffer)
-	sd := make([]byte, getSecurityDescriptorLength(sdBuffer))
-	copy(sd, (*[0xffff]byte)(unsafe.Pointer(sdBuffer))[:len(sd)])
-	return sd, nil
+	b := unsafe.Slice((*byte)(unsafe.Pointer(sd)), unsafe.Sizeof(windows.SECURITY_DESCRIPTOR{}))
+	return b, nil
 }
 
 func SecurityDescriptorToSddl(sd []byte) (string, error) {
-	var sddl *uint16
-	// The returned string length seems to include an arbitrary number of terminating NULs.
-	// Don't use it.
-	err := convertSecurityDescriptorToStringSecurityDescriptor(&sd[0], 1, 0xff, &sddl, nil)
-	if err != nil {
-		return "", err
+	if l := int(unsafe.Sizeof(windows.SECURITY_DESCRIPTOR{})); len(sd) < l {
+		return "", fmt.Errorf("SecurityDescriptor (%d) smaller than expected (%d): %w", len(sd), l, windows.ERROR_INCORRECT_SIZE)
 	}
-	defer localFree(uintptr(unsafe.Pointer(sddl)))
-	return syscall.UTF16ToString((*[0xffff]uint16)(unsafe.Pointer(sddl))[:]), nil
+	s := (*windows.SECURITY_DESCRIPTOR)(unsafe.Pointer(&sd[0]))
+	return s.String(), nil
 }

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -45,39 +45,35 @@ var (
 	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
 	modws2_32   = windows.NewLazySystemDLL("ws2_32.dll")
 
-	procAdjustTokenPrivileges                                = modadvapi32.NewProc("AdjustTokenPrivileges")
-	procConvertSecurityDescriptorToStringSecurityDescriptorW = modadvapi32.NewProc("ConvertSecurityDescriptorToStringSecurityDescriptorW")
-	procConvertSidToStringSidW                               = modadvapi32.NewProc("ConvertSidToStringSidW")
-	procConvertStringSecurityDescriptorToSecurityDescriptorW = modadvapi32.NewProc("ConvertStringSecurityDescriptorToSecurityDescriptorW")
-	procConvertStringSidToSidW                               = modadvapi32.NewProc("ConvertStringSidToSidW")
-	procGetSecurityDescriptorLength                          = modadvapi32.NewProc("GetSecurityDescriptorLength")
-	procImpersonateSelf                                      = modadvapi32.NewProc("ImpersonateSelf")
-	procLookupAccountNameW                                   = modadvapi32.NewProc("LookupAccountNameW")
-	procLookupAccountSidW                                    = modadvapi32.NewProc("LookupAccountSidW")
-	procLookupPrivilegeDisplayNameW                          = modadvapi32.NewProc("LookupPrivilegeDisplayNameW")
-	procLookupPrivilegeNameW                                 = modadvapi32.NewProc("LookupPrivilegeNameW")
-	procLookupPrivilegeValueW                                = modadvapi32.NewProc("LookupPrivilegeValueW")
-	procOpenThreadToken                                      = modadvapi32.NewProc("OpenThreadToken")
-	procRevertToSelf                                         = modadvapi32.NewProc("RevertToSelf")
-	procBackupRead                                           = modkernel32.NewProc("BackupRead")
-	procBackupWrite                                          = modkernel32.NewProc("BackupWrite")
-	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
-	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
-	procCreateIoCompletionPort                               = modkernel32.NewProc("CreateIoCompletionPort")
-	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
-	procDisconnectNamedPipe                                  = modkernel32.NewProc("DisconnectNamedPipe")
-	procGetCurrentThread                                     = modkernel32.NewProc("GetCurrentThread")
-	procGetNamedPipeHandleStateW                             = modkernel32.NewProc("GetNamedPipeHandleStateW")
-	procGetNamedPipeInfo                                     = modkernel32.NewProc("GetNamedPipeInfo")
-	procGetQueuedCompletionStatus                            = modkernel32.NewProc("GetQueuedCompletionStatus")
-	procLocalAlloc                                           = modkernel32.NewProc("LocalAlloc")
-	procLocalFree                                            = modkernel32.NewProc("LocalFree")
-	procSetFileCompletionNotificationModes                   = modkernel32.NewProc("SetFileCompletionNotificationModes")
-	procNtCreateNamedPipeFile                                = modntdll.NewProc("NtCreateNamedPipeFile")
-	procRtlDefaultNpAcl                                      = modntdll.NewProc("RtlDefaultNpAcl")
-	procRtlDosPathNameToNtPathName_U                         = modntdll.NewProc("RtlDosPathNameToNtPathName_U")
-	procRtlNtStatusToDosErrorNoTeb                           = modntdll.NewProc("RtlNtStatusToDosErrorNoTeb")
-	procWSAGetOverlappedResult                               = modws2_32.NewProc("WSAGetOverlappedResult")
+	procAdjustTokenPrivileges              = modadvapi32.NewProc("AdjustTokenPrivileges")
+	procConvertSidToStringSidW             = modadvapi32.NewProc("ConvertSidToStringSidW")
+	procConvertStringSidToSidW             = modadvapi32.NewProc("ConvertStringSidToSidW")
+	procGetSecurityDescriptorLength        = modadvapi32.NewProc("GetSecurityDescriptorLength")
+	procImpersonateSelf                    = modadvapi32.NewProc("ImpersonateSelf")
+	procLookupAccountNameW                 = modadvapi32.NewProc("LookupAccountNameW")
+	procLookupAccountSidW                  = modadvapi32.NewProc("LookupAccountSidW")
+	procLookupPrivilegeDisplayNameW        = modadvapi32.NewProc("LookupPrivilegeDisplayNameW")
+	procLookupPrivilegeNameW               = modadvapi32.NewProc("LookupPrivilegeNameW")
+	procLookupPrivilegeValueW              = modadvapi32.NewProc("LookupPrivilegeValueW")
+	procOpenThreadToken                    = modadvapi32.NewProc("OpenThreadToken")
+	procRevertToSelf                       = modadvapi32.NewProc("RevertToSelf")
+	procBackupRead                         = modkernel32.NewProc("BackupRead")
+	procBackupWrite                        = modkernel32.NewProc("BackupWrite")
+	procCancelIoEx                         = modkernel32.NewProc("CancelIoEx")
+	procConnectNamedPipe                   = modkernel32.NewProc("ConnectNamedPipe")
+	procCreateIoCompletionPort             = modkernel32.NewProc("CreateIoCompletionPort")
+	procCreateNamedPipeW                   = modkernel32.NewProc("CreateNamedPipeW")
+	procDisconnectNamedPipe                = modkernel32.NewProc("DisconnectNamedPipe")
+	procGetCurrentThread                   = modkernel32.NewProc("GetCurrentThread")
+	procGetNamedPipeHandleStateW           = modkernel32.NewProc("GetNamedPipeHandleStateW")
+	procGetNamedPipeInfo                   = modkernel32.NewProc("GetNamedPipeInfo")
+	procGetQueuedCompletionStatus          = modkernel32.NewProc("GetQueuedCompletionStatus")
+	procSetFileCompletionNotificationModes = modkernel32.NewProc("SetFileCompletionNotificationModes")
+	procNtCreateNamedPipeFile              = modntdll.NewProc("NtCreateNamedPipeFile")
+	procRtlDefaultNpAcl                    = modntdll.NewProc("RtlDefaultNpAcl")
+	procRtlDosPathNameToNtPathName_U       = modntdll.NewProc("RtlDosPathNameToNtPathName_U")
+	procRtlNtStatusToDosErrorNoTeb         = modntdll.NewProc("RtlNtStatusToDosErrorNoTeb")
+	procWSAGetOverlappedResult             = modws2_32.NewProc("WSAGetOverlappedResult")
 )
 
 func adjustTokenPrivileges(token windows.Token, releaseAll bool, input *byte, outputSize uint32, output *byte, requiredSize *uint32) (success bool, err error) {
@@ -93,33 +89,8 @@ func adjustTokenPrivileges(token windows.Token, releaseAll bool, input *byte, ou
 	return
 }
 
-func convertSecurityDescriptorToStringSecurityDescriptor(sd *byte, revision uint32, secInfo uint32, sddl **uint16, sddlSize *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall6(procConvertSecurityDescriptorToStringSecurityDescriptorW.Addr(), 5, uintptr(unsafe.Pointer(sd)), uintptr(revision), uintptr(secInfo), uintptr(unsafe.Pointer(sddl)), uintptr(unsafe.Pointer(sddlSize)), 0)
-	if r1 == 0 {
-		err = errnoErr(e1)
-	}
-	return
-}
-
 func convertSidToStringSid(sid *byte, str **uint16) (err error) {
 	r1, _, e1 := syscall.Syscall(procConvertSidToStringSidW.Addr(), 2, uintptr(unsafe.Pointer(sid)), uintptr(unsafe.Pointer(str)), 0)
-	if r1 == 0 {
-		err = errnoErr(e1)
-	}
-	return
-}
-
-func convertStringSecurityDescriptorToSecurityDescriptor(str string, revision uint32, sd *uintptr, size *uint32) (err error) {
-	var _p0 *uint16
-	_p0, err = syscall.UTF16PtrFromString(str)
-	if err != nil {
-		return
-	}
-	return _convertStringSecurityDescriptorToSecurityDescriptor(_p0, revision, sd, size)
-}
-
-func _convertStringSecurityDescriptorToSecurityDescriptor(str *uint16, revision uint32, sd *uintptr, size *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall6(procConvertStringSecurityDescriptorToSecurityDescriptorW.Addr(), 4, uintptr(unsafe.Pointer(str)), uintptr(revision), uintptr(unsafe.Pointer(sd)), uintptr(unsafe.Pointer(size)), 0, 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
@@ -229,7 +200,7 @@ func _lookupPrivilegeValue(systemName *uint16, name *uint16, luid *uint64) (err 
 	return
 }
 
-func openThreadToken(thread syscall.Handle, accessMask uint32, openAsSelf bool, token *windows.Token) (err error) {
+func openThreadToken(thread windows.Handle, accessMask uint32, openAsSelf bool, token *windows.Token) (err error) {
 	var _p0 uint32
 	if openAsSelf {
 		_p0 = 1
@@ -249,7 +220,7 @@ func revertToSelf() (err error) {
 	return
 }
 
-func backupRead(h syscall.Handle, b []byte, bytesRead *uint32, abort bool, processSecurity bool, context *uintptr) (err error) {
+func backupRead(h windows.Handle, b []byte, bytesRead *uint32, abort bool, processSecurity bool, context *uintptr) (err error) {
 	var _p0 *byte
 	if len(b) > 0 {
 		_p0 = &b[0]
@@ -269,7 +240,7 @@ func backupRead(h syscall.Handle, b []byte, bytesRead *uint32, abort bool, proce
 	return
 }
 
-func backupWrite(h syscall.Handle, b []byte, bytesWritten *uint32, abort bool, processSecurity bool, context *uintptr) (err error) {
+func backupWrite(h windows.Handle, b []byte, bytesWritten *uint32, abort bool, processSecurity bool, context *uintptr) (err error) {
 	var _p0 *byte
 	if len(b) > 0 {
 		_p0 = &b[0]
@@ -289,7 +260,7 @@ func backupWrite(h syscall.Handle, b []byte, bytesWritten *uint32, abort bool, p
 	return
 }
 
-func cancelIoEx(file syscall.Handle, o *syscall.Overlapped) (err error) {
+func cancelIoEx(file windows.Handle, o *windows.Overlapped) (err error) {
 	r1, _, e1 := syscall.Syscall(procCancelIoEx.Addr(), 2, uintptr(file), uintptr(unsafe.Pointer(o)), 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -297,7 +268,7 @@ func cancelIoEx(file syscall.Handle, o *syscall.Overlapped) (err error) {
 	return
 }
 
-func connectNamedPipe(pipe syscall.Handle, o *syscall.Overlapped) (err error) {
+func connectNamedPipe(pipe windows.Handle, o *windows.Overlapped) (err error) {
 	r1, _, e1 := syscall.Syscall(procConnectNamedPipe.Addr(), 2, uintptr(pipe), uintptr(unsafe.Pointer(o)), 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -305,16 +276,16 @@ func connectNamedPipe(pipe syscall.Handle, o *syscall.Overlapped) (err error) {
 	return
 }
 
-func createIoCompletionPort(file syscall.Handle, port syscall.Handle, key uintptr, threadCount uint32) (newport syscall.Handle, err error) {
+func createIoCompletionPort(file windows.Handle, port windows.Handle, key uintptr, threadCount uint32) (newport windows.Handle, err error) {
 	r0, _, e1 := syscall.Syscall6(procCreateIoCompletionPort.Addr(), 4, uintptr(file), uintptr(port), uintptr(key), uintptr(threadCount), 0, 0)
-	newport = syscall.Handle(r0)
+	newport = windows.Handle(r0)
 	if newport == 0 {
 		err = errnoErr(e1)
 	}
 	return
 }
 
-func createNamedPipe(name string, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *syscall.SecurityAttributes) (handle syscall.Handle, err error) {
+func createNamedPipe(name string, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *windows.SecurityAttributes) (handle windows.Handle, err error) {
 	var _p0 *uint16
 	_p0, err = syscall.UTF16PtrFromString(name)
 	if err != nil {
@@ -323,16 +294,16 @@ func createNamedPipe(name string, flags uint32, pipeMode uint32, maxInstances ui
 	return _createNamedPipe(_p0, flags, pipeMode, maxInstances, outSize, inSize, defaultTimeout, sa)
 }
 
-func _createNamedPipe(name *uint16, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *syscall.SecurityAttributes) (handle syscall.Handle, err error) {
+func _createNamedPipe(name *uint16, flags uint32, pipeMode uint32, maxInstances uint32, outSize uint32, inSize uint32, defaultTimeout uint32, sa *windows.SecurityAttributes) (handle windows.Handle, err error) {
 	r0, _, e1 := syscall.Syscall9(procCreateNamedPipeW.Addr(), 8, uintptr(unsafe.Pointer(name)), uintptr(flags), uintptr(pipeMode), uintptr(maxInstances), uintptr(outSize), uintptr(inSize), uintptr(defaultTimeout), uintptr(unsafe.Pointer(sa)), 0)
-	handle = syscall.Handle(r0)
-	if handle == syscall.InvalidHandle {
+	handle = windows.Handle(r0)
+	if handle == windows.InvalidHandle {
 		err = errnoErr(e1)
 	}
 	return
 }
 
-func disconnectNamedPipe(pipe syscall.Handle) (err error) {
+func disconnectNamedPipe(pipe windows.Handle) (err error) {
 	r1, _, e1 := syscall.Syscall(procDisconnectNamedPipe.Addr(), 1, uintptr(pipe), 0, 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -340,13 +311,13 @@ func disconnectNamedPipe(pipe syscall.Handle) (err error) {
 	return
 }
 
-func getCurrentThread() (h syscall.Handle) {
+func getCurrentThread() (h windows.Handle) {
 	r0, _, _ := syscall.Syscall(procGetCurrentThread.Addr(), 0, 0, 0, 0)
-	h = syscall.Handle(r0)
+	h = windows.Handle(r0)
 	return
 }
 
-func getNamedPipeHandleState(pipe syscall.Handle, state *uint32, curInstances *uint32, maxCollectionCount *uint32, collectDataTimeout *uint32, userName *uint16, maxUserNameSize uint32) (err error) {
+func getNamedPipeHandleState(pipe windows.Handle, state *uint32, curInstances *uint32, maxCollectionCount *uint32, collectDataTimeout *uint32, userName *uint16, maxUserNameSize uint32) (err error) {
 	r1, _, e1 := syscall.Syscall9(procGetNamedPipeHandleStateW.Addr(), 7, uintptr(pipe), uintptr(unsafe.Pointer(state)), uintptr(unsafe.Pointer(curInstances)), uintptr(unsafe.Pointer(maxCollectionCount)), uintptr(unsafe.Pointer(collectDataTimeout)), uintptr(unsafe.Pointer(userName)), uintptr(maxUserNameSize), 0, 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -354,7 +325,7 @@ func getNamedPipeHandleState(pipe syscall.Handle, state *uint32, curInstances *u
 	return
 }
 
-func getNamedPipeInfo(pipe syscall.Handle, flags *uint32, outSize *uint32, inSize *uint32, maxInstances *uint32) (err error) {
+func getNamedPipeInfo(pipe windows.Handle, flags *uint32, outSize *uint32, inSize *uint32, maxInstances *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procGetNamedPipeInfo.Addr(), 5, uintptr(pipe), uintptr(unsafe.Pointer(flags)), uintptr(unsafe.Pointer(outSize)), uintptr(unsafe.Pointer(inSize)), uintptr(unsafe.Pointer(maxInstances)), 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -362,7 +333,7 @@ func getNamedPipeInfo(pipe syscall.Handle, flags *uint32, outSize *uint32, inSiz
 	return
 }
 
-func getQueuedCompletionStatus(port syscall.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) {
+func getQueuedCompletionStatus(port windows.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procGetQueuedCompletionStatus.Addr(), 5, uintptr(port), uintptr(unsafe.Pointer(bytes)), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(o)), uintptr(timeout), 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -370,18 +341,7 @@ func getQueuedCompletionStatus(port syscall.Handle, bytes *uint32, key *uintptr,
 	return
 }
 
-func localAlloc(uFlags uint32, length uint32) (ptr uintptr) {
-	r0, _, _ := syscall.Syscall(procLocalAlloc.Addr(), 2, uintptr(uFlags), uintptr(length), 0)
-	ptr = uintptr(r0)
-	return
-}
-
-func localFree(mem uintptr) {
-	syscall.Syscall(procLocalFree.Addr(), 1, uintptr(mem), 0, 0)
-	return
-}
-
-func setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err error) {
+func setFileCompletionNotificationModes(h windows.Handle, flags uint8) (err error) {
 	r1, _, e1 := syscall.Syscall(procSetFileCompletionNotificationModes.Addr(), 2, uintptr(h), uintptr(flags), 0)
 	if r1 == 0 {
 		err = errnoErr(e1)
@@ -389,7 +349,7 @@ func setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err erro
 	return
 }
 
-func ntCreateNamedPipeFile(pipe *syscall.Handle, access uint32, oa *objectAttributes, iosb *ioStatusBlock, share uint32, disposition uint32, options uint32, typ uint32, readMode uint32, completionMode uint32, maxInstances uint32, inboundQuota uint32, outputQuota uint32, timeout *int64) (status ntStatus) {
+func ntCreateNamedPipeFile(pipe *windows.Handle, access ntAccessMask, oa *objectAttributes, iosb *ioStatusBlock, share ntFileShareMode, disposition ntFileCreationDisposition, options ntFileOptions, typ uint32, readMode uint32, completionMode uint32, maxInstances uint32, inboundQuota uint32, outputQuota uint32, timeout *int64) (status ntStatus) {
 	r0, _, _ := syscall.Syscall15(procNtCreateNamedPipeFile.Addr(), 14, uintptr(unsafe.Pointer(pipe)), uintptr(access), uintptr(unsafe.Pointer(oa)), uintptr(unsafe.Pointer(iosb)), uintptr(share), uintptr(disposition), uintptr(options), uintptr(typ), uintptr(readMode), uintptr(completionMode), uintptr(maxInstances), uintptr(inboundQuota), uintptr(outputQuota), uintptr(unsafe.Pointer(timeout)), 0)
 	status = ntStatus(r0)
 	return
@@ -415,7 +375,7 @@ func rtlNtStatusToDosError(status ntStatus) (winerr error) {
 	return
 }
 
-func wsaGetOverlappedResult(h syscall.Handle, o *syscall.Overlapped, bytes *uint32, wait bool, flags *uint32) (err error) {
+func wsaGetOverlappedResult(h windows.Handle, o *windows.Overlapped, bytes *uint32, wait bool, flags *uint32) (err error) {
 	var _p0 uint32
 	if wait {
 		_p0 = 1


### PR DESCRIPTION
Where ever possible, use `golang.org/x/sys/windows` instead of `syscall` (which has been deprecated since go1.11).

Using `windows.LocalFree` requires using `unsafe.Pointer`, which ensures that the Go garbage collector does not try to free memory pre-maturely if it was previously declared as a pointer.

Since `syscall.Handle` is part of API for `vhd` package, it was left unchanged.

For security descriptor functions, switch to using `windows.SECURITY_DESCRIPTOR` to avoid unnecessary byte manipulation and panics due to missing input validation and error checking.