### PR TITLE
sd.go: fix calculation of security descriptor length in SddlToSecurit…

### DIFF
--- a/sd.go
+++ b/sd.go
@@ -15,7 +15,6 @@ import (
 //sys lookupAccountSid(systemName *uint16, sid *byte, name *uint16, nameSize *uint32, refDomain *uint16, refDomainSize *uint32, sidNameUse *uint32) (err error) = advapi32.LookupAccountSidW
 //sys convertSidToStringSid(sid *byte, str **uint16) (err error) = advapi32.ConvertSidToStringSidW
 //sys convertStringSidToSid(str *uint16, sid **byte) (err error) = advapi32.ConvertStringSidToSidW
-//sys getSecurityDescriptorLength(sd uintptr) (len uint32) = advapi32.GetSecurityDescriptorLength
 
 type AccountLookupError struct {
 	Name string
@@ -121,7 +120,7 @@ func SddlToSecurityDescriptor(sddl string) ([]byte, error) {
 	if err != nil {
 		return nil, &SddlConversionError{Sddl: sddl, Err: err}
 	}
-	b := unsafe.Slice((*byte)(unsafe.Pointer(sd)), unsafe.Sizeof(windows.SECURITY_DESCRIPTOR{}))
+	b := unsafe.Slice((*byte)(unsafe.Pointer(sd)), sd.Length())
 	return b, nil
 }
 

--- a/zsyscall_windows.go
+++ b/zsyscall_windows.go
@@ -48,7 +48,6 @@ var (
 	procAdjustTokenPrivileges              = modadvapi32.NewProc("AdjustTokenPrivileges")
 	procConvertSidToStringSidW             = modadvapi32.NewProc("ConvertSidToStringSidW")
 	procConvertStringSidToSidW             = modadvapi32.NewProc("ConvertStringSidToSidW")
-	procGetSecurityDescriptorLength        = modadvapi32.NewProc("GetSecurityDescriptorLength")
 	procImpersonateSelf                    = modadvapi32.NewProc("ImpersonateSelf")
 	procLookupAccountNameW                 = modadvapi32.NewProc("LookupAccountNameW")
 	procLookupAccountSidW                  = modadvapi32.NewProc("LookupAccountSidW")
@@ -102,12 +101,6 @@ func convertStringSidToSid(str *uint16, sid **byte) (err error) {
 	if r1 == 0 {
 		err = errnoErr(e1)
 	}
-	return
-}
-
-func getSecurityDescriptorLength(sd uintptr) (len uint32) {
-	r0, _, _ := syscall.Syscall(procGetSecurityDescriptorLength.Addr(), 1, uintptr(sd), 0, 0)
-	len = uint32(r0)
 	return
 }
 


### PR DESCRIPTION
…yDescriptor

unsafe.Sizeof(windows.SECURITY_DESCRIPTOR{}) is the minimum length of the SD, not the actual length. Use the actual length for computing the length of the slice.

This path also removes getSecurityDescriptorLength, which is no longer used.