### PR TITLE
Rename module to github.com/microsoft/go-winio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Microsoft/go-winio
+module github.com/microsoft/go-winio
 
 go 1.17
 


### PR DESCRIPTION
The Microsoft GitHub organization uses a lowercase 'm', which other go modules from Microsoft also use. This module using an uppercase M can cause problems in certain build systems when using macOS which uses a case-insensitive file system by default: https://github.com/NixOS/nixpkgs/issues/273998