### PR TITLE
switch back from golang.org/x/sys/execabs to os/exec (go1.19)

### DIFF
--- a/pkg/security/grantvmgroupaccess_test.go
+++ b/pkg/security/grantvmgroupaccess_test.go
@@ -5,12 +5,11 @@ package security
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 const (


### PR DESCRIPTION
- relates to https://github.com/microsoft/go-winio/pull/195

This reverts commit f2a56450f4feb316514aa0f5978a989fe6b1a328, which switched from os/exec to the golang.org/x/sys/execabs package to mitigate security issues (mainly on Windows) with lookups resolving to binaries in the current directory.

from the go1.19 release notes https://go.dev/doc/go1.19#os-exec-path

> ## PATH lookups
>
> Command and LookPath no longer allow results from a PATH search to be found
> relative to the current directory. This removes a common source of security
> problems but may also break existing programs that depend on using, say,
> exec.Command("prog") to run a binary named prog (or, on Windows, prog.exe) in
> the current directory. See the os/exec package documentation for information
> about how best to update such programs.
>
> On Windows, Command and LookPath now respect the NoDefaultCurrentDirectoryInExePath
> environment variable, making it possible to disable the default implicit search
> of “.” in PATH lookups on Windows systems.