### PR TITLE
[release/0.5] fileinfo: internally fix FileBasicInfo memory alignment (#312)

### DIFF
--- a/pkg/fs/fs_windows_test.go
+++ b/pkg/fs/fs_windows_test.go
@@ -17,7 +17,9 @@ func TestGetFSTypeOfKnownDrive(t *testing.T) {
 }
 
 func TestGetFSTypeOfInvalidPath(t *testing.T) {
-	_, err := GetFileSystemType("7:\\")
+	// [filepath.VolumeName] doesn't mandate that the drive letters matches [a-zA-Z].
+	// Instead, use non-character drive.
+	_, err := GetFileSystemType(`No:\`)
 	if err != ErrInvalidPath {
 		t.Fatalf("Expected `ErrInvalidPath`, got %v", err)
 	}


### PR DESCRIPTION
* fileinfo: internally fix FileBasicInfo memory alignment



* Update test with review feedback

Remove unused winName.

Extract more into Windows alignment consts to repeat less.

Document reason for having multiple alignment consts for the same value.



---------


(cherry picked from commit 008bc6ea439f15884bef0b52f2772190c382bf46)