### PR TITLE
fix dangerous uintptr conversion

### DIFF
--- a/pkg/etw/newprovider.go
+++ b/pkg/etw/newprovider.go
@@ -5,7 +5,6 @@ package etw
 import (
 	"bytes"
 	"encoding/binary"
-	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
 	"golang.org/x/sys/windows"
@@ -62,8 +61,7 @@ func NewProviderWithOptions(name string, options ...ProviderOpt) (provider *Prov
 	if err := eventSetInformation(
 		provider.handle,
 		eventInfoClassProviderSetTraits,
-		uintptr(unsafe.Pointer(&provider.metadata[0])),
-		uint32(len(provider.metadata)),
+		provider.metadata,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/etw/syscall.go
+++ b/pkg/etw/syscall.go
@@ -8,8 +8,8 @@ package etw
 
 //sys eventUnregister_64(providerHandle providerHandle) (win32err error) = advapi32.EventUnregister
 //sys eventWriteTransfer_64(providerHandle providerHandle, descriptor *eventDescriptor, activityID *windows.GUID, relatedActivityID *windows.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
-//sys eventSetInformation_64(providerHandle providerHandle, class eventInfoClass, information uintptr, length uint32) (win32err error) = advapi32.EventSetInformation
+//sys eventSetInformation_64(providerHandle providerHandle, class eventInfoClass, information []byte) (win32err error) = advapi32.EventSetInformation
 
 //sys eventUnregister_32(providerHandle_low uint32, providerHandle_high uint32) (win32err error) = advapi32.EventUnregister
 //sys eventWriteTransfer_32(providerHandle_low uint32, providerHandle_high uint32, descriptor *eventDescriptor, activityID *windows.GUID, relatedActivityID *windows.GUID, dataDescriptorCount uint32, dataDescriptors *eventDataDescriptor) (win32err error) = advapi32.EventWriteTransfer
-//sys eventSetInformation_32(providerHandle_low uint32, providerHandle_high uint32, class eventInfoClass, information uintptr, length uint32) (win32err error) = advapi32.EventSetInformation
+//sys eventSetInformation_32(providerHandle_low uint32, providerHandle_high uint32, class eventInfoClass, information []byte) (win32err error) = advapi32.EventSetInformation

--- a/pkg/etw/wrapper_32.go
+++ b/pkg/etw/wrapper_32.go
@@ -40,15 +40,13 @@ func eventWriteTransfer(
 func eventSetInformation(
 	providerHandle providerHandle,
 	class eventInfoClass,
-	information uintptr,
-	length uint32) (win32err error) {
+	information []byte) (win32err error) {
 
 	return eventSetInformation_32(
 		low(providerHandle),
 		high(providerHandle),
 		class,
-		information,
-		length)
+		information)
 }
 
 // providerCallbackAdapter acts as the first-level callback from the C/ETW side

--- a/pkg/etw/wrapper_64.go
+++ b/pkg/etw/wrapper_64.go
@@ -30,13 +30,11 @@ func eventWriteTransfer(
 func eventSetInformation(
 	providerHandle providerHandle,
 	class eventInfoClass,
-	information uintptr,
-	length uint32) (win32err error) {
+	information []byte) (win32err error) {
 	return eventSetInformation_64(
 		providerHandle,
 		class,
-		information,
-		length)
+		information)
 }
 
 // providerCallbackAdapter acts as the first-level callback from the C/ETW side

--- a/pkg/etw/zsyscall_windows.go
+++ b/pkg/etw/zsyscall_windows.go
@@ -53,16 +53,24 @@ func eventRegister(providerId *windows.GUID, callback uintptr, callbackContext u
 	return
 }
 
-func eventSetInformation_64(providerHandle providerHandle, class eventInfoClass, information uintptr, length uint32) (win32err error) {
-	r0, _, _ := syscall.SyscallN(procEventSetInformation.Addr(), uintptr(providerHandle), uintptr(class), uintptr(information), uintptr(length))
+func eventSetInformation_64(providerHandle providerHandle, class eventInfoClass, information []byte) (win32err error) {
+	var _p0 *byte
+	if len(information) > 0 {
+		_p0 = &information[0]
+	}
+	r0, _, _ := syscall.SyscallN(procEventSetInformation.Addr(), uintptr(providerHandle), uintptr(class), uintptr(unsafe.Pointer(_p0)), uintptr(len(information)))
 	if r0 != 0 {
 		win32err = syscall.Errno(r0)
 	}
 	return
 }
 
-func eventSetInformation_32(providerHandle_low uint32, providerHandle_high uint32, class eventInfoClass, information uintptr, length uint32) (win32err error) {
-	r0, _, _ := syscall.SyscallN(procEventSetInformation.Addr(), uintptr(providerHandle_low), uintptr(providerHandle_high), uintptr(class), uintptr(information), uintptr(length))
+func eventSetInformation_32(providerHandle_low uint32, providerHandle_high uint32, class eventInfoClass, information []byte) (win32err error) {
+	var _p0 *byte
+	if len(information) > 0 {
+		_p0 = &information[0]
+	}
+	r0, _, _ := syscall.SyscallN(procEventSetInformation.Addr(), uintptr(providerHandle_low), uintptr(providerHandle_high), uintptr(class), uintptr(unsafe.Pointer(_p0)), uintptr(len(information)))
 	if r0 != 0 {
 		win32err = syscall.Errno(r0)
 	}

--- a/pkg/security/grantvmgroupaccess.go
+++ b/pkg/security/grantvmgroupaccess.go
@@ -5,7 +5,6 @@ package security
 import (
 	"fmt"
 	"os"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -33,7 +32,7 @@ type (
 		multipleTrusteeOperation int32
 		trusteeForm              trusteeForm
 		trusteeType              trusteeType
-		name                     uintptr
+		name                     *windows.SID
 	}
 )
 
@@ -153,13 +152,13 @@ func generateDACLWithAcesAdded(name string, isDir bool, origDACL uintptr) (uintp
 			trustee: trustee{
 				trusteeForm: trusteeFormIsSID,
 				trusteeType: trusteeTypeWellKnownGroup,
-				name:        uintptr(unsafe.Pointer(sid)),
+				name:        sid,
 			},
 		},
 	}
 
 	modifiedDACL := uintptr(0)
-	if err := setEntriesInAcl(uintptr(uint32(1)), uintptr(unsafe.Pointer(&eaArray[0])), origDACL, &modifiedDACL); err != nil {
+	if err := setEntriesInAcl(uintptr(uint32(1)), &eaArray[0], origDACL, &modifiedDACL); err != nil {
 		return 0, fmt.Errorf("%s SetEntriesInAcl %s: %w", gvmga, name, err)
 	}
 

--- a/pkg/security/syscall_windows.go
+++ b/pkg/security/syscall_windows.go
@@ -4,4 +4,4 @@ package security
 
 //sys getSecurityInfo(handle windows.Handle, objectType uint32, si uint32, ppsidOwner **uintptr, ppsidGroup **uintptr, ppDacl *uintptr, ppSacl *uintptr, ppSecurityDescriptor *uintptr) (win32err error) = advapi32.GetSecurityInfo
 //sys setSecurityInfo(handle windows.Handle, objectType uint32, si uint32, psidOwner uintptr, psidGroup uintptr, pDacl uintptr, pSacl uintptr) (win32err error) = advapi32.SetSecurityInfo
-//sys setEntriesInAcl(count uintptr, pListOfEEs uintptr, oldAcl uintptr, newAcl *uintptr) (win32err error) = advapi32.SetEntriesInAclW
+//sys setEntriesInAcl(count uintptr, pListOfEEs *explicitAccess, oldAcl uintptr, newAcl *uintptr) (win32err error) = advapi32.SetEntriesInAclW

--- a/pkg/security/zsyscall_windows.go
+++ b/pkg/security/zsyscall_windows.go
@@ -52,8 +52,8 @@ func getSecurityInfo(handle windows.Handle, objectType uint32, si uint32, ppsidO
 	return
 }
 
-func setEntriesInAcl(count uintptr, pListOfEEs uintptr, oldAcl uintptr, newAcl *uintptr) (win32err error) {
-	r0, _, _ := syscall.SyscallN(procSetEntriesInAclW.Addr(), uintptr(count), uintptr(pListOfEEs), uintptr(oldAcl), uintptr(unsafe.Pointer(newAcl)))
+func setEntriesInAcl(count uintptr, pListOfEEs *explicitAccess, oldAcl uintptr, newAcl *uintptr) (win32err error) {
+	r0, _, _ := syscall.SyscallN(procSetEntriesInAclW.Addr(), uintptr(count), uintptr(unsafe.Pointer(pListOfEEs)), uintptr(oldAcl), uintptr(unsafe.Pointer(newAcl)))
 	if r0 != 0 {
 		win32err = syscall.Errno(r0)
 	}


### PR DESCRIPTION
According to: https://pkg.go.dev/unsafe#Pointer `Unsafe.Pointer` rule 4:

> For the compiler to recognize this pattern, the conversion must appear in the argument list:
> 
> // INVALID: uintptr cannot be stored in variable
> // before implicit conversion back to Pointer during system call.
> u := uintptr(unsafe.Pointer(p))
> syscall.Syscall(SYS_READ, uintptr(fd), u, uintptr(n))

Storing a go pointer to `uintptr` variable is **dangerous**, the address of the go variable that the `uintptr` pointers to may change (stack grow), or the variable be garbage-collected(`uintptr` doesn't ref the value).
Even worse, the original address may be reused by another goroutine, and if the syscall writes to that address, it's can cause memory corruption and random runtime errors.

