### PR TITLE
Add support for LX symlinks (0xA000001D) for WSL/MSYS2 compatibility

### DIFF
--- a/reparse.go
+++ b/reparse.go
@@ -1,11 +1,11 @@
 //go:build windows
-// +build windows
 
 package winio
 
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode/utf16"
@@ -61,7 +61,7 @@ func DecodeReparsePointData(tag uint32, b []byte) (*ReparsePoint, error) {
 	case reparseTagLxSymlink:
 		// LX symlinks store the target as UTF-8 after a 4-byte version field
 		if len(b) < 4 {
-			return nil, fmt.Errorf("LX symlink buffer too short")
+			return nil, errors.New("LX symlink buffer too short")
 		}
 		targetBytes := b[4:]
 		for i, c := range targetBytes {

--- a/reparse.go
+++ b/reparse.go
@@ -124,7 +124,6 @@ func encodeLxReparsePoint(rp *ReparsePoint) []byte {
 }
 
 func encodeWindowsReparsePoint(rp *ReparsePoint) []byte {
-
 	// Generate an NT path and determine if this is a relative path.
 	var ntTarget string
 	relative := false

--- a/reparse_lx_test.go
+++ b/reparse_lx_test.go
@@ -1,0 +1,60 @@
+//go:build windows
+// +build windows
+
+package winio
+
+import (
+	"testing"
+)
+
+func TestLxSymlinkRoundTrip(t *testing.T) {
+	// Test LX symlink encode/decode
+	original := &ReparsePoint{
+		Target:      "/usr/bin/bash",
+		IsMountPoint: false,
+		IsLxSymlink:  true,
+	}
+
+	// Encode
+	encoded := EncodeReparsePoint(original)
+	
+	// Decode
+	decoded, err := DecodeReparsePoint(encoded)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	// Verify
+	if decoded.Target != original.Target {
+		t.Errorf("Target mismatch: got %q, want %q", decoded.Target, original.Target)
+	}
+	if decoded.IsLxSymlink != original.IsLxSymlink {
+		t.Errorf("IsLxSymlink mismatch: got %v, want %v", decoded.IsLxSymlink, original.IsLxSymlink)
+	}
+	if decoded.IsMountPoint != original.IsMountPoint {
+		t.Errorf("IsMountPoint mismatch: got %v, want %v", decoded.IsMountPoint, original.IsMountPoint)
+	}
+}
+
+func TestWindowsSymlinkNotLx(t *testing.T) {
+	// Test that regular Windows symlinks are not marked as LX
+	original := &ReparsePoint{
+		Target:      `C:\Windows\System32`,
+		IsMountPoint: false,
+		IsLxSymlink:  false,
+	}
+
+	// Encode
+	encoded := EncodeReparsePoint(original)
+	
+	// Decode
+	decoded, err := DecodeReparsePoint(encoded)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	// Verify it's NOT an LX symlink
+	if decoded.IsLxSymlink {
+		t.Errorf("Windows symlink incorrectly marked as LX symlink")
+	}
+}

--- a/reparse_lx_test.go
+++ b/reparse_lx_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package winio
 
@@ -10,14 +9,14 @@ import (
 func TestLxSymlinkRoundTrip(t *testing.T) {
 	// Test LX symlink encode/decode
 	original := &ReparsePoint{
-		Target:      "/usr/bin/bash",
+		Target:       "/usr/bin/bash",
 		IsMountPoint: false,
 		IsLxSymlink:  true,
 	}
 
 	// Encode
 	encoded := EncodeReparsePoint(original)
-	
+
 	// Decode
 	decoded, err := DecodeReparsePoint(encoded)
 	if err != nil {
@@ -39,14 +38,14 @@ func TestLxSymlinkRoundTrip(t *testing.T) {
 func TestWindowsSymlinkNotLx(t *testing.T) {
 	// Test that regular Windows symlinks are not marked as LX
 	original := &ReparsePoint{
-		Target:      `C:\Windows\System32`,
+		Target:       `C:\Windows\System32`,
 		IsMountPoint: false,
 		IsLxSymlink:  false,
 	}
 
 	// Encode
 	encoded := EncodeReparsePoint(original)
-	
+
 	// Decode
 	decoded, err := DecodeReparsePoint(encoded)
 	if err != nil {


### PR DESCRIPTION
## Summary
Adds support for LX symlinks (IO_REPARSE_TAG_LX_SYMLINK, tag 0xA000001D) used by WSL and MSYS2 for native Unix-style symlinks.

## Problem
Docker builds using MSYS2 with native symlinks (MSYS=winsymlinks:native) fail with error "unsupported reparse point a000001d" because go-winio doesn't recognize LX symlink reparse tags.

## Solution
- Added `reparseTagLxSymlink` constant (0xA000001D)
- Implemented decode for LX symlinks (UTF-8 format with 4-byte version prefix)
- Added `IsLxSymlink` field to preserve symlink type through encode/decode cycles
- Implemented encode to recreate LX symlinks in native format

## Testing
- Unit tests for encode/decode round-trip
- Validated with Docker MSYS2 container builds
- Tested docker commit, save/load cycles preserve LX symlinks correctly