### PR TITLE
[lint] fix revive.use-any issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,11 +42,6 @@ issues:
       text: "^comment-spacings: no space between comment delimiter and comment text"
       source: "//(cspell:|nolint:|sys |todo)"
 
-    # not on go 1.18 yet, so no any
-    - linters:
-        - revive
-      text: "^use-any: since GO 1.18 'interface{}' can be replaced by 'any'"
-
     # allow unjustified ignores of error checks in defer statements
     - linters:
         - nolintlint

--- a/internal/stringbuffer/wstring.go
+++ b/internal/stringbuffer/wstring.go
@@ -16,7 +16,7 @@ const MinWStringCap = 310
 // is copied to heap and then referenced via pointer in the interface header that sync.Pool
 // stores.
 var pathPool = sync.Pool{ // if go1.18+ adds Pool[T], use that to store []uint16 directly
-	New: func() interface{} {
+	New: func() any {
 		b := make([]uint16, MinWStringCap)
 		return &b
 	},

--- a/pkg/etw/fieldopt.go
+++ b/pkg/etw/fieldopt.go
@@ -411,7 +411,7 @@ func Time(name string, value time.Time) FieldOpt {
 // type. The intent of this is to make it easier to see which types are not
 // supported in traces, so we can evaluate adding support for more types in the
 // future.
-func SmartField(name string, v interface{}) FieldOpt {
+func SmartField(name string, v any) FieldOpt {
 	switch v := v.(type) {
 	case bool:
 		return BoolField(name, v)

--- a/pkg/etwlogrus/hook_test.go
+++ b/pkg/etwlogrus/hook_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func fireEvent(name string, value interface{}) {
+func fireEvent(name string, value any) {
 	logrus.WithField("Field", value).Info(name)
 }
 


### PR DESCRIPTION
Because the project uses [Go 1.23](https://github.com/microsoft/go-winio/blob/ad3df93bed29459e88baf3ece3e167e2f5d922dd/go.mod#L3).