### PR TITLE
Fix win32File.socket flag and add TestHvSockFlagIsSet

### DIFF
--- a/file.go
+++ b/file.go
@@ -120,7 +120,7 @@ func (f *win32File) closeHandle() {
 		f.wg.Wait()
 		// at this point, no new IO can start
 		if f.socket {
-			windows.Closesocket(f.handle)
+			_ = windows.Closesocket(f.handle)
 		} else {
 			windows.Close(f.handle)
 		}

--- a/file.go
+++ b/file.go
@@ -119,7 +119,11 @@ func (f *win32File) closeHandle() {
 		_ = cancelIoEx(f.handle, nil)
 		f.wg.Wait()
 		// at this point, no new IO can start
-		windows.Close(f.handle)
+		if f.socket {
+			windows.Closesocket(f.handle)
+		} else {
+			windows.Close(f.handle)
+		}
 		f.handle = 0
 	} else {
 		f.wgLock.Unlock()

--- a/hvsock_test.go
+++ b/hvsock_test.go
@@ -671,3 +671,10 @@ func mustBeType[T any](tb testing.TB, v any) T {
 	}
 	return v2
 }
+func TestHvSockFlagIsSet(t *testing.T) {
+	u := newUtil(t)
+	cl, sv, _ := clientServer(u)
+
+	u.Assert(cl.sock.socket, "Client win32File.socket should be true")
+	u.Assert(sv.sock.socket, "Server win32File.socket should be true")
+}


### PR DESCRIPTION
Fixes #330

### Description
Hyper-V sockets were previously closed using `CloseHandle`, which is incorrect for socket resources according to Windows documentation. This change updates `win32File.closeHandle` to correctly use `closesocket` when the underlying handle is a socket.

### Changes
- Updated `closeHandle` in `file.go` to use `windows.Closesocket` if `f.socket` is true.
- Added `TestHvSockFlagIsSet` to `hvsock_test.go` to verify that `HvsockConn` and `HvsockListener` correctly set the `socket` flag, ensuring the correct close path is taken.