### PR TITLE
Modify CI workflow OS matrix and test commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, ubuntu-latest]
+        os: [windows-2022, windows-2025, ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,18 +105,7 @@ jobs:
 
       - name: Test repo
         shell: pwsh
-        run: |
-          # `go test -race` requires mingw on windows, and there is some weirdness on windows 2019
-          # which causes tests to fail with `"exit status 0xc0000139"`.
-          # Even trying to update mingw with choco still fails.
-          #
-          # see: https://go.dev/doc/articles/race_detector#Requirements
-
-          if ( '${{ matrix.os }}' -ne 'windows-2019' ) {
-            $race = '-race'
-          }
-
-          gotestsum --format standard-verbose --debug -- -gcflags=all=-d=checkptr $race -v ./...
+        run: gotestsum --format standard-verbose --debug -- -gcflags=all=-d=checkptr $race -v ./...
 
       # !NOTE:
       # Fuzzing cannot be run across multiple packages, (ie, `go -fuzz "^Fuzz" ./...` fails).


### PR DESCRIPTION
Updated CI workflow to use Windows 2025 and removed legacy Windows 2019 handling. Ref: https://github.com/actions/runner-images