### PR TITLE
fix possible nil pointer dereference in providerCallback

### DIFF
--- a/pkg/etw/provider.go
+++ b/pkg/etw/provider.go
@@ -77,19 +77,21 @@ func providerCallback(
 ) {
 	provider := providers.getProvider(uint(i))
 
-	switch state {
-	case ProviderStateCaptureState:
-	case ProviderStateDisable:
-		provider.enabled = false
-	case ProviderStateEnable:
-		provider.enabled = true
-		provider.level = level
-		provider.keywordAny = matchAnyKeyword
-		provider.keywordAll = matchAllKeyword
-	}
+	if provider != nil {
+		switch state {
+		case ProviderStateCaptureState:
+		case ProviderStateDisable:
+			provider.enabled = false
+		case ProviderStateEnable:
+			provider.enabled = true
+			provider.level = level
+			provider.keywordAny = matchAnyKeyword
+			provider.keywordAll = matchAllKeyword
+		}
 
-	if provider.callback != nil {
-		provider.callback(sourceID, state, level, matchAnyKeyword, matchAllKeyword, filterData)
+		if provider.callback != nil {
+			provider.callback(sourceID, state, level, matchAnyKeyword, matchAllKeyword, filterData)
+		}
 	}
 }
 


### PR DESCRIPTION
It is possible to hit a nil pointer dereference in `providerCallback` if a notification fires after `go-winio` has already stopped tracking the provider - `provider` will come back `nil` from `providers.getProvider` and then any access in the `switch` (like `provider.enabled = false`) will panic.

Seemed simple to fix by just wrapping the entire callback in a `nil` check, I hope this is helpful!