### PR TITLE
fix(pipe): handle ERROR_BROKEN_PIPE during concurrent Accept()

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -470,7 +470,9 @@ func (l *win32PipeListener) listenerRoutine() {
 				p, err = l.makeConnectedServerPipe()
 				// If the connection was immediately closed by the client, try
 				// again.
-				if err != windows.ERROR_NO_DATA { //nolint:errorlint // err is Errno
+				// Treat ERROR_BROKEN_PIPE as retryable, similar to ERROR_NO_DATA, 
+				// as it indicates a client disconnected before the connection was fully accepted.
+				if err != windows.ERROR_NO_DATA && err != windows.ERROR_BROKEN_PIPE { //nolint:errorlint // err is Errno
 					break
 				}
 			}

--- a/pipe_race_test.go
+++ b/pipe_race_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package winio
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAcceptBrokenPipeRace(t *testing.T) {
+	path := `\\.\pipe\test-broken-pipe-race`
+	l, err := ListenPipe(path, nil)
+	if err != nil {
+		t.Fatalf("ListenPipe failed: %v", err)
+	}
+	
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				if err == ErrPipeListenerClosed || err == net.ErrClosed {
+					break
+				}
+				panic(fmt.Sprintf("Accept failed: %v", err))
+			}
+			conn.Close()
+		}
+		close(done)
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := DialPipe(path, nil)
+			if err == nil {
+				conn.Close()
+			}
+		}()
+	}
+
+	wg.Wait()
+	l.Close()
+	
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out")
+	}
+}


### PR DESCRIPTION
Problem:
Under heavy load on Windows, a race condition occurs when a client connects to a named pipe but disconnects immediately before the IOCP event is processed. This causes the underlying asyncIO to return windows.ERROR_BROKEN_PIPE. The listenerRoutine currently catches ERROR_NO_DATA to retry, but unhandled broken pipes cause the loop to break, bubbling the error up to Accept() and panicking or crashing the parent server loop.

Fix:
Added windows.ERROR_BROKEN_PIPE to the retry condition inside listenerRoutine(). This treats an immediate client disconnect as a transient, retryable state, matching the existing logic for ERROR_NO_DATA.

Verification:

Added pipe_race_test.go (TestAcceptBrokenPipeRace) to simulate rapid dial-and-close sequences against the listener.

Verified the listener now survives the race condition without exiting prematurely.
