### PR TITLE
pipe: make consumed listener close authoritative

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -444,13 +444,13 @@ func (l *win32PipeListener) makeConnectedServerPipe() (*win32File, error) {
 			p = nil
 		}
 	case <-l.closeCh:
-		// Abort the connect request by closing the handle.
-		p.Close()
+		// Abort the connect request by closing the handle. Consuming
+		// closeCh makes closure authoritative: ConnectNamedPipe may race
+		// cancellation and return a connection result instead.
+		_ = p.Close()
 		p = nil
-		err = <-ch
-		if err == nil || err == ErrFileClosed { //nolint:errorlint // err is Errno
-			err = ErrPipeListenerClosed
-		}
+		<-ch
+		err = ErrPipeListenerClosed
 	}
 	return p, err
 }

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -15,6 +15,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+
+	"github.com/Microsoft/go-winio/internal/fs"
 )
 
 var testPipeName = `\\.\pipe\winiotestpipe`
@@ -217,6 +219,154 @@ func TestCloseAbortsListen(t *testing.T) {
 	err = <-ch
 	if !errors.Is(err, ErrPipeListenerClosed) {
 		t.Fatalf("expected ErrPipeListenerClosed, got %v", err)
+	}
+}
+
+func TestListenerCloseRacesPendingConnect(t *testing.T) {
+	// Regression test for issue #85. Closing the listener while a client
+	// connect is in flight must not lose the close signal, even when
+	// ConnectNamedPipe races the handle close and reports a connection
+	// (ERROR_PIPE_CONNECTED, normalized to nil) or a client disconnect
+	// (ERROR_NO_DATA) instead of ErrFileClosed.
+	for i := 0; i < 50; i++ {
+		l, err := ListenPipe(testPipeName, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		acceptCh := make(chan error, 1)
+		go func() {
+			for {
+				c, err := l.Accept()
+				if err != nil {
+					acceptCh <- err
+					return
+				}
+				c.Close()
+			}
+		}()
+
+		dialDone := make(chan struct{})
+		go func() {
+			defer close(dialDone)
+			// Dial and disconnect immediately so the raced connect can
+			// complete or fail with ERROR_NO_DATA on the server side.
+			timeout := 250 * time.Millisecond
+			c, err := DialPipe(testPipeName, &timeout)
+			if err == nil {
+				c.Close()
+			}
+		}()
+
+		// Vary the interleaving between the connect and the close.
+		time.Sleep(time.Duration(i%5) * 100 * time.Microsecond)
+
+		closeDone := make(chan struct{})
+		go func() {
+			l.Close()
+			close(closeDone)
+		}()
+
+		select {
+		case <-closeDone:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iteration %d: Close did not complete; close signal was lost", i)
+		}
+
+		select {
+		case err := <-acceptCh:
+			if !errors.Is(err, ErrPipeListenerClosed) {
+				t.Fatalf("iteration %d: expected ErrPipeListenerClosed, got %v", i, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iteration %d: Accept did not fail after Close", i)
+		}
+		<-dialDone
+	}
+}
+
+func TestListenerCloseOverridesRacedConnect(t *testing.T) {
+	// Regression test for issue #85. Once makeConnectedServerPipe consumes
+	// the close signal, it must report ErrPipeListenerClosed even when the
+	// raced ConnectNamedPipe already completed with a different result: a
+	// client that attaches before ConnectNamedPipe is called produces a
+	// synchronous ERROR_PIPE_CONNECTED (normalized to nil by connectPipe),
+	// and one that also disconnects first produces ERROR_NO_DATA. If either
+	// result overrides the consumed close, listenerRoutine keeps running
+	// with the single close signal already spent and Listener.Close hangs.
+	c := PipeConfig{}
+	first, err := makeServerPipeHandle(testPipeName, nil, &c, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer windows.Close(first)
+
+	l := &win32PipeListener{
+		firstHandle: first,
+		path:        testPipeName,
+		config:      c,
+		closeCh:     make(chan int),
+		doneCh:      make(chan int),
+	}
+
+	dial := func() (windows.Handle, error) {
+		return fs.CreateFile(testPipeName,
+			fs.GENERIC_READ|fs.GENERIC_WRITE,
+			0,   // mode
+			nil, // security attributes
+			fs.OPEN_EXISTING,
+			fs.FILE_FLAG_OVERLAPPED|fs.SECURITY_SQOS_PRESENT|fs.SECURITY_ANONYMOUS,
+			0, // template file handle
+		)
+	}
+
+	type result struct {
+		p   *win32File
+		err error
+	}
+	for i := 0; i < 100; i++ {
+		resCh := make(chan result, 1)
+		go func() {
+			p, err := l.makeConnectedServerPipe()
+			resCh <- result{p, err}
+		}()
+
+		// Attach and disconnect as soon as the server pipe exists so the
+		// raced connect can complete with ERROR_NO_DATA or
+		// ERROR_PIPE_CONNECTED instead of ErrFileClosed.
+		for a := 0; a < 200; a++ {
+			if cl, err := dial(); err == nil {
+				windows.Close(cl)
+				break
+			}
+		}
+
+		// Race the close signal against the completed connect.
+		closeSent := make(chan struct{})
+		go func() {
+			l.closeCh <- 1
+			close(closeSent)
+		}()
+
+		var res result
+		select {
+		case res = <-resCh:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iteration %d: makeConnectedServerPipe did not return", i)
+		}
+		consumed := false
+		select {
+		case <-l.closeCh:
+			// The connect result won the race; drain our close signal.
+		case <-closeSent:
+			consumed = true
+		}
+		if res.p != nil {
+			res.p.Close()
+		}
+		if consumed && !errors.Is(res.err, ErrPipeListenerClosed) {
+			t.Fatalf("iteration %d: close signal consumed, expected ErrPipeListenerClosed, got %v", i, res.err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #85. Once `makeConnectedServerPipe` consumes the listener's close signal,
treat closure as authoritative and always return `ErrPipeListenerClosed`,
instead of reusing a raced `ConnectNamedPipe` result.

## Problem

`win32PipeListener.Close()` sends a single value on `l.closeCh`. When
`makeConnectedServerPipe` receives it, the current code closes the pending pipe
handle and then reuses the connect goroutine's result, converting only `nil`
and `ErrFileClosed` to `ErrPipeListenerClosed`.

Closing the handle does not guarantee the connect result is one of those two. A
client that attaches in the window before `ConnectNamedPipe` is called makes it
return synchronously: `ERROR_PIPE_CONNECTED` (which `connectPipe` normalizes to
`nil`) if the client is still attached, or `ERROR_NO_DATA` if it already
disconnected. In the `ERROR_NO_DATA` case the error is passed through,
`listenerRoutine`'s retry loop calls `makeConnectedServerPipe` again, and the
one close signal has already been spent: the new connect pends forever and
`Close()` waits forever on `l.doneCh`.

## Solution

Once `makeConnectedServerPipe` receives from `l.closeCh`, that close is
authoritative. It still closes the pending pipe handle and drains the connect
result so the goroutine completes, but always returns
`ErrPipeListenerClosed`, which stops `listenerRoutine`.

Two regression tests:

- `TestListenerCloseOverridesRacedConnect` drives `makeConnectedServerPipe`
  directly: a raw client attaches and disconnects in the pre-connect window
  (reliably producing the synchronous `ERROR_NO_DATA`), then a close signal
  races the connect result. It fails within a few iterations on the current
  code and passes with this change.
- `TestListenerCloseRacesPendingConnect` races `Accept`, a dialing client, and
  `Listener.Close` end to end, with bounded timeouts so a regression fails
  instead of hanging the test process.

## Testing

- `go test -race -count=100 -run 'Test.*Listener.*Close' .`
- `go test -race .`
- `golangci-lint run --config=.golangci.yml` clean (v1.64.8)
- `go generate ./...` with no generated diff
- Verified `TestListenerCloseOverridesRacedConnect` fails on unpatched `main`
  with `expected ErrPipeListenerClosed, got The pipe is being closed.`

## Related work

PR #324 also touches listener shutdown synchronization more broadly (PR #364
did as well before it was closed). This patch is limited to the specific
lost-close race from #85: the goroutine that consumes `closeCh` must not let a
raced connect result override listener closure.
